### PR TITLE
Fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ the applicability and manageability of the QUIC transport protocol.
 ## Applicability
 
 * [Editor's copy](https://quicwg.github.io/ops-drafts/draft-ietf-quic-applicability.html)
-* [Working Group Draft] (https://tools.ietf.org/html/draft-ietf-quic-applicability)
-* [Compare Individual Draft and Editor's copy] (https://tools.ietf.org/rfcdiff?url1=https://tools.ietf.org/id/draft-ietf-quic-applicability.txt&url2=https://quicwg.github.io/ops-drafts/draft-ietf-quic-applicability.txt)
+* [Working Group Draft](https://tools.ietf.org/html/draft-ietf-quic-applicability)
+* [Compare Individual Draft and Editor's copy](https://tools.ietf.org/rfcdiff?url1=https://tools.ietf.org/id/draft-ietf-quic-applicability.txt&url2=https://quicwg.github.io/ops-drafts/draft-ietf-quic-applicability.txt)
 
 ## Manageability
 
 * [Editor's copy](https://quicwg.github.io/ops-drafts/draft-ietf-quic-manageability.html)
-* [Working Group Draft] (https://tools.ietf.org/html/draft-ietf-quic-manageability)
-* [Compare Individual Draft and Editor's copy] (https://tools.ietf.org/rfcdiff?url1=https://tools.ietf.org/id/draft-ietf-quic-manageability.txt&url2=https://quicwg.github.io/ops-drafts/draft-ietf-quic-manageability.txt)
+* [Working Group Draft](https://tools.ietf.org/html/draft-ietf-quic-manageability)
+* [Compare Individual Draft and Editor's copy](https://tools.ietf.org/rfcdiff?url1=https://tools.ietf.org/id/draft-ietf-quic-manageability.txt&url2=https://quicwg.github.io/ops-drafts/draft-ietf-quic-manageability.txt)
 
 ## Building the Draft
 


### PR DESCRIPTION
I wonder if this isn't a consequence of an editor configuration issue, maybe in @mnot's editor, because there was definitely no spaces in the script that generated this file.