### PR TITLE
Cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# See http://editorconfig.org
+
+root = true
+
+[*.md]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+MD_PREPROCESSOR := sed -e 's/{DATE}/$(shell date '+%Y-%m')/g'
+
 include lib/main.mk
 
 lib/main.mk:
@@ -7,3 +9,19 @@ ifneq (,$(shell git submodule status lib 2>/dev/null))
 else
 	git clone -q --depth 10 -b master https://github.com/martinthomson/i-d-template.git lib
 endif
+
+latest::
+	@err=0; for f in draft-*.md ; do \
+	  if grep -n ' $$' "$$f"; then \
+	    echo "$$f contains trailing whitespace"; err=1; \
+	  fi; \
+	  if cat "$$f" | (l=0; while read -r a; do l=$$(($$l + 1)); echo -E "$$l:$$a"; done) | \
+	     sed -e '1,/--- abstract/d;/^[0-9]*: *|/d' | tr -d '\r' | grep '^[0-9]*:.\{81\}'; then \
+	    echo "$$f contains a line with >80 characters"; err=1; \
+	  fi; \
+	  if cat "$$f" | (l=0; while read -r a; do l=$$(($$l + 1)); echo -E "$$l:$$a"; done) | \
+	     sed -e '/^[0-9]*:~~~/,/^[0-9]*:~~~/p;/^[0-9]*:```/,/^[0-9]*:```/p;d' | \
+	     tr -d '\r' | grep '^[0-9]*:.\{70\}'; then \
+	    echo "$$f contains a figure with >69 characters"; err=1; \
+	  fi; \
+	done; [ "$$err" -eq 0 ]

--- a/circle.yml
+++ b/circle.yml
@@ -3,16 +3,21 @@ machine:
     GOPATH: "${HOME}/${CIRCLE_PROJECT_REPONAME}/.go_workspace"
     mmark_src: github.com/miekg/mmark/mmark
     mmark: ./mmark
+  python:
+    version: 3.5.2
 
 checkout:
   post:
-    - git fetch origin gh-pages --depth 10
+    - if [ -e .git/shallow ]; then git fetch origin --unshallow; fi
+    - git fetch origin gh-pages
 
 dependencies:
   pre:
     - pip install xml2rfc
     - if head -1 -q *.md | grep '^\-\-\-' >/dev/null 2>&1; then gem install --no-doc kramdown-rfc2629; fi
     - if head -1 -q *.md | grep '^%%%' >/dev/null 2>&1; then go get "$mmark_src" && go build "$mmark_src"; fi
+  cache_directories:
+    - "/opt/circleci/.rvm/gems"
 
 test:
   override:
@@ -22,4 +27,6 @@ deployment:
   production:
     branch: /.*/
     commands:
-      - make ghpages
+      - make artifacts
+      - make ghpages || make ghpages
+      - make ghissues || make ghissues

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -39,7 +39,7 @@ informative:
         ins: B. Trammell
       -
         ins: M. Kuehlewind
-    url: https://ripe72.ripe.net/wp-content/uploads/presentations/86-atlas-udpdiff.pdf
+    target: https://ripe72.ripe.net/wp-content/uploads/presentations/86-atlas-udpdiff.pdf
     date: 2016-05-25
   Edeline16:
     title: Using UDP for Internet Transport Evolution (arXiv preprint 1612.07816)
@@ -54,21 +54,21 @@ informative:
         ins: E. Aben
       -
         ins: B. Donnet
-    url: https://arxiv.org/abs/1612.07816
+    target: https://arxiv.org/abs/1612.07816
     date: 2016-12-22
   Swett16:
     title: QUIC Deployment Experience at Google (IETF96 QUIC BoF presentation)
     author:
       -
         ins: I. Swett
-    url: https://www.ietf.org/proceedings/96/slides/slides-96-quic-3.pdf
+    target: https://www.ietf.org/proceedings/96/slides/slides-96-quic-3.pdf
     date: 2016-07-20
   PaaschNanog:
     title: Network Ssupport for TCP Fast Open (NANOG 67 presentation)
     author:
       -
         ins: C. Paasch
-    url: https://www.nanog.org/sites/default/files/Paasch_Network_Support.pdf
+    target: https://www.nanog.org/sites/default/files/Paasch_Network_Support.pdf
     date: 2016-06-13
   I-D.nottingham-httpbis-retry:
 --- abstract

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -30,11 +30,8 @@ author:
 
 normative:
   RFC2119:
-  I-D.ietf-quic-transport:
-  I-D.ietf-quic-tls:
 
 informative:
-  I-D.ietf-quic-http:
   Trammell16:
     title: Internet Path Transparency Measurements using RIPE Atlas (RIPE72 MAT presentation)
     author:
@@ -85,29 +82,29 @@ to QUIC, and implementors of these application protocols.
 
 # Introduction
 
-QUIC {{I-D.ietf-quic-transport}} is a new transport protocol currently under
-development in the IETF quic working group, focusing on support of semantics as
-needed for HTTP/2 {{I-D.ietf-quic-http}} such as stream-multiplexing to avoid
-head-of-line blocking. Based on current deployment practices, QUIC is
-encapsulated in UDP. The version of QUIC
-that is currently under development will integrate TLS 1.3 {{I-D.ietf-quic-tls}}
-to encrypt all payload data and most control information.
+QUIC {{!QUIC=I-D.ietf-quic-transport}} is a new transport protocol currently
+under development in the IETF quic working group, focusing on support of
+semantics as needed for HTTP/2 {{?QUIC-HTTP=I-D.ietf-quic-http}} such as
+stream-multiplexing to avoid head-of-line blocking. Based on current deployment
+practices, QUIC is encapsulated in UDP. The version of QUIC that is currently
+under development will integrate TLS 1.3 {{!TLS13=I-D.ietf-quic-tls}} to
+encrypt all payload data and most control information.
 
-This document provides guidance for application developers that want to use the QUIC
-protocol without implementing it on their own. This includes general guidance
-for application use of HTTP/2 over QUIC as well as the use of other
+This document provides guidance for application developers that want to use the
+QUIC protocol without implementing it on their own. This includes general
+guidance for application use of HTTP/2 over QUIC as well as the use of other
 application layer protocols over QUIC. For specific guidance on how to
-integrate HTTP/2 with QUIC, see {{I-D.ietf-quic-http}}.
+integrate HTTP/2 with QUIC, see {{QUIC-HTTP}}.
 
-In the following sections we discuss specific caveats to QUIC's
-applicability, and issues that application developers must consider when using
-QUIC as a transport for their application.
+In the following sections we discuss specific caveats to QUIC's applicability,
+and issues that application developers must consider when using QUIC as a
+transport for their application.
 
 ## Notational Conventions
 
 The words "MUST", "MUST NOT", "SHOULD", and "MAY" are used in this document.
-It's not shouting; when these words are capitalized, they have a special meaning
-as defined in {{RFC2119}}.
+It's not shouting; when these words are capitalized, they have a special
+meaning as defined in {{RFC2119}}.
 
 # The Necessity of Fallback {#fallback}
 
@@ -144,24 +141,28 @@ the user that secure communication is unavailable.
 
 # Session resumption versus Keep-alive
 
-[EDITOR'S NOTE: guidance/recommendation to us 0-RTT session resumption rather then sending keep-alives?]
+\[EDITOR'S NOTE: guidance/recommendation to us 0-RTT session resumption rather
+then sending keep-alives?]
 
 # Zero RTT {#zero-rtt}
 
 QUIC provides for 0-RTT connection establishment (see section 3.2 of
-{{I-D.ietf-quic-transport}}). This presents opportunities and challenges for
-applications using QUIC.
+{{!QUIC}}). This presents opportunities and challenges for applications using
+QUIC.
 
 ## Thinking in zero RTT
 
-[Editor's Note: Jana noted at the interim in Paris that we should point out that applications need to be re-thought slightly to get the benefits of zero RTT. Add a little text here to discuss this and why it's worth the effort, before we go straight into the dragons.]
+\[Editor's Note: Jana noted at the interim in Paris that we should point out
+that applications need to be re-thought slightly to get the benefits of zero
+RTT. Add a little text here to discuss this and why it's worth the effort,
+before we go straight into the dragons.]
 
-## Here There Be Dragons 
+## Here There Be Dragons
 
 However, data in the frames contained in 0-RTT packets of a such a connection
 must be treated specially by the application layer. Replay of these packets can
 cause the data to processed twice. This is further described in
-{{I-D.nottingham-httpbis-retry}}.
+{{?HTTP-RETRY=I-D.nottingham-httpbis-retry}}.
 
 0-RTT data also does not benefit from perfect forward secrecy (PFS).
 
@@ -175,36 +176,38 @@ idempotent, and/or whether PFS is a hard requirement
 
 QUIC's stream multiplexing feature allows applications to run multiple streams
 over a single connection, without head-of-line blocking between streams,
-associated at a point in time with a single five-tuple. Streams are
-meaningful only to the application; since stream information is carried inside
-QUIC's encryption boundary, no information about the stream(s) whose frames
-are carried by a given packet is visible to the network.
+associated at a point in time with a single five-tuple. Streams are meaningful
+only to the application; since stream information is carried inside QUIC's
+encryption boundary, no information about the stream(s) whose frames are
+carried by a given packet is visible to the network.
 
 Stream multiplexing is not intended to be used for differentiating streams in
 terms of network treatment. Application traffic requiring different network
 treatment SHOULD therefore be carried over different five-tuples (i.e.
 multiple QUIC connections). Given QUIC's ability to send application data in
-the first RTT of a connection (if a previous connection to the same host
-has been successfully established to provide the respective credentials), the
+the first RTT of a connection (if a previous connection to the same host has
+been successfully established to provide the respective credentials), the
 cost for establishing another connection are extremely low.
 
 # Prioritization
 
 Stream prioritization is not exposed to the network, nor to the receiver.
-Prioritization can be realized by the sender and the QUIC transport should provide
-and interface for applications to prioritize streams {{I-D.ietf-quic-transport}}.
+Prioritization can be realized by the sender and the QUIC transport should
+provide and interface for applications to prioritize streams {{!QUIC}}.
 
-Priority handling of retransmissions may be implemented by the sender in the transport layer and
-{{I-D.ietf-quic-transport}} does not specify a specific way how this must be
-handled. Currently QUIC only provides fully reliable stream transmission, and as such
-prioritization of retransmission is likely beneficial. For not fully reliable streams
-priority scheduling of retransmissions over data of higher-priority streams might not be
-desired. In this case QUIC could also provide an interface or derive the prioritization
-decision from the reliability level of the stream.
+Priority handling of retransmissions may be implemented by the sender in the
+transport layer and {{QUIC}} does not specify a specific way how this must be
+handled. Currently QUIC only provides fully reliable stream transmission, and
+as such prioritization of retransmission is likely beneficial. For not fully
+reliable streams priority scheduling of retransmissions over data of
+higher-priority streams might not be desired. In this case QUIC could also
+provide an interface or derive the prioritization decision from the reliability
+level of the stream.
 
 # Graceful connection closure
 
-[EDITOR'S NOTE: give some guidance here about the steps an application should take; however this is still work in progress]
+\[EDITOR'S NOTE: give some guidance here about the steps an application should
+take; however this is still work in progress]
 
 
 # Information exposure and the Connection ID {#connid}
@@ -215,28 +218,29 @@ information is intended to be used by the network. QUIC has a long header that
 is used during connection establishment and for other control processes, and a
 short header that may be used for data transmission in an established
 connection. While the long header is fixed and exposes some information, the
-short header only exposes the packet number by default and may optionally expose
-a connection ID.  
+short header only exposes the packet number by default and may optionally
+expose a connection ID.
 
 Given that exposing this information may make it possible to associate multiple
-addresses with a single client during rebinding, which has privacy implications,
-an application may indicate to not support exposure of certain information after
-the handshake. Specificially, an application that has additional information
-that the client is not behind a NAT and the server is not behind a load
-balancer, and therefore it is unlikely that the addresses will be re-bound, may
-indicate to the transport that is wishes to not expose a connection ID.
+addresses with a single client during rebinding, which has privacy
+implications, an application may indicate to not support exposure of certain
+information after the handshake. Specificially, an application that has
+additional information that the client is not behind a NAT and the server is
+not behind a load balancer, and therefore it is unlikely that the addresses
+will be re-bound, may indicate to the transport that is wishes to not expose a
+connection ID.
 
 ## Server-Generated Connection ID
 
-QUIC supports a server-generated Connection ID, transmitted to the client during
-connection establishment: see section 5.7 of {{I-D.ietf-quic-transport}} Servers
-behind load balancers should propose a Connection ID during the handshake,
-encoding the identity of the server or information about its load balancing
-pool, in order to support stateless load balancing. Once the server generates a
+QUIC supports a server-generated Connection ID, transmitted to the client
+during connection establishment: see Section 5.7 of {{!QUIC}} Servers behind
+load balancers should propose a Connection ID during the handshake, encoding
+the identity of the server or information about its load balancing pool, in
+order to support stateless load balancing. Once the server generates a
 Connection ID that encodes its identity, every CDN load balancer would be able
 to forward the packets to that server without needing information about every
 specific flow it is forwarding.
-  
+
 Server-generated Connection IDs must not encode any information other that that
 needed to route packets to the appropriate backend server(s): typically the
 identity of the backend server or pool of servers, if the data-center’s load
@@ -266,17 +270,17 @@ redirect the next Client Initial packet to a different server in that pool.
 
 # Use of Versions and Cryptographic Handshake
 
-Versioning in QUIC may change the the protocol's behavior completely, except for
-the meaning of a few header fields that have been declared to be fixed. As such
-version of QUIC with a higher version number does not necessarily provide a
-better service, but might simply provide a very different service, so an
+Versioning in QUIC may change the the protocol's behavior completely, except
+for the meaning of a few header fields that have been declared to be fixed. As
+such version of QUIC with a higher version number does not necessarily provide
+a better service, but might simply provide a very different service, so an
 application needs to be able to select which versions of QUIC it wants to use.
 
 A new version could use an encryption scheme other than TLS 1.3 or higher.
-{{I-D.ietf-quic-transport}} specifies requirements for the cryptographic
-handshake as currently realized by TLS 1.3 and described in a separate
-specification {{I-D.ietf-quic-tls}}. This split is performed to enable
-light-weight versioning with different cryptographic handshakes.
+{{QUIC}} specifies requirements for the cryptographic handshake as currently
+realized by TLS 1.3 and described in a separate specification
+{{!QUIC-TLS=I-D.ietf-quic-tls}}. This split is performed to enable light-weight
+versioning with different cryptographic handshakes.
 
 # IANA Considerations
 
@@ -284,15 +288,15 @@ This document has no actions for IANA.
 
 # Security Considerations
 
-See the security considerations in {{I-D.ietf-quic-transport}} and
-{{I-D.ietf-quic-tls}}; the security considerations for the underlying transport
-protocol are relevant for applications using QUIC, as well.
+See the security considerations in {{!QUIC}} and {{!QUIC-TLS}}; the security
+considerations for the underlying transport protocol are relevant for
+applications using QUIC, as well.
 
 Application developers should note that any fallback they use when QUIC cannot
 be used due to network blocking of UDP SHOULD guarantee the same security
-properties as QUIC; if this is not possible, the connection SHOULD fail to allow
-the application to explicitly handle fallback to a less-secure alternative. See
-{{fallback}}.
+properties as QUIC; if this is not possible, the connection SHOULD fail to
+allow the application to explicitly handle fallback to a less-secure
+alternative. See {{fallback}}.
 
 # Contributors
 

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -45,7 +45,7 @@ informative:
         ins: R. Beverly
       -
         ins: B. Trammell
-    url: https://arxiv.org/abs/1612.02902
+    target: https://arxiv.org/abs/1612.02902
     date: 2016-12-09
   Ding2015:
     title: TCP Stretch Acknowledgments and Timestamps - Findings and Impliciations for Passive RTT Measurement (ACM Computer Communication Review)
@@ -54,7 +54,7 @@ informative:
         ins: H. Ding
       -
         ins: M. Rabinovich
-    url: http://www.sigcomm.org/sites/default/files/ccr/papers/2015/July/0000000-0000002.pdf
+    target: http://www.sigcomm.org/sites/default/files/ccr/papers/2015/July/0000000-0000002.pdf
     date: 2015-07
 
 --- abstract

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -27,23 +27,19 @@ author:
     street: Gloriastrasse 35
     city: 8092 Zurich
     country: Switzerland
-  - 
+  -
     ins: D. Druta
     name: Dan Druta
     org: AT&T
     email: dd5826@att.com
 
 normative:
-  RFC2119:
-  I-D.ietf-quic-transport:
-  I-D.ietf-quic-tls:
 
 informative:
-  RFC7011:
   IPIM:
     title: In-Protocol Internet Measurement (arXiv preprint 1612.02902)
     author:
-      - 
+      -
         ins: M. Allman
       -
         ins: R. Beverly
@@ -54,14 +50,12 @@ informative:
   Ding2015:
     title: TCP Stretch Acknowledgments and Timestamps - Findings and Impliciations for Passive RTT Measurement (ACM Computer Communication Review)
     author:
-      - 
+      -
         ins: H. Ding
       -
         ins: M. Rabinovich
     url: http://www.sigcomm.org/sites/default/files/ccr/papers/2015/July/0000000-0000002.pdf
-    date: 2015-07 
-  I-D.ietf-quic-http:
-  I-D.trammell-plus-statefulness:
+    date: 2015-07
 
 --- abstract
 
@@ -74,15 +68,16 @@ of QUIC-aware middleboxes, e.g. for load balancing.
 
 # Introduction
 
-QUIC {{I-D.ietf-quic-transport}} is a new transport protocol currently under
-development in the IETF quic working group, focusing on support of semantics as
-needed for HTTP/2 {{I-D.ietf-quic-http}}. Based on current deployment practices, QUIC is
-encapsulated in UDP and encrypted by default. The current version of QUIC
-integrates TLS {{I-D.ietf-quic-tls}}
-to encrypt all payload data and most control information. Given QUIC is an
-end-to-end transport protocol, all information in the protocol header, even that
-which can be inspected, is is not meant to be mutable by the network, and will
-therefore be integrity-protected to the extent possible.
+QUIC {{!QUIC=I-D.ietf-quic-transport}} is a new transport protocol currently
+under development in the IETF quic working group, focusing on support of
+semantics as needed for HTTP/2 {{!QUIC-HTTP=I-D.ietf-quic-http}}. Based on
+current deployment practices, QUIC is encapsulated in UDP and encrypted by
+default. The current version of QUIC integrates TLS
+{{!QUIC-TLS=I-D.ietf-quic-tls}} to encrypt all payload data and most control
+information. Given QUIC is an end-to-end transport protocol, all information in
+the protocol header, even that which can be inspected, is is not meant to be
+mutable by the network, and will therefore be integrity-protected to the extent
+possible.
 
 This document provides guidance for network operation on the management of QUIC
 traffic. This includes guidance on how to interpret and utilize information that
@@ -97,7 +92,7 @@ compliance requirements, for example, would be impermissible on other networks
 without those requirements. This document therefore does not make any specific
 recommendations as to which practices should or should not be applied; for each
 practice, it describes what is and is not possible with the QUIC transport
-protocol as defined. 
+protocol as defined.
 
 QUIC is at the moment very much a moving target. This document refers the state
 of the QUIC working group drafts as well as to changes under discussion, via
@@ -107,7 +102,7 @@ issues and pull requests in GitHub current as of the time of writing.
 
 The words "MUST", "MUST NOT", "SHOULD", and "MAY" are used in this document.
 It's not shouting; when these words are capitalized, they have a special meaning
-as defined in {{RFC2119}}.
+as defined in {{!RFC2119}}.
 
 # Features of the QUIC Wire Image
 
@@ -116,23 +111,39 @@ have an impact on the design and operation of devices that forward QUIC packets.
 Here, we are concerned primarily with QUIC's unencrypted wire image, which we
 define as the information available in the packet header in each QUIC packet,
 and the dynamics of that information. Since QUIC is a versioned protocol,
-also the wire image of the header format can change. However, at least 
+also the wire image of the header format can change. However, at least
 the mechanism by which a receiver can determine which version is used and the
-meaning and location of fields used in the version negotiation process need to be fixed. 
+meaning and location of fields used in the version negotiation process need to
+be fixed.
 
-This document is focused on the protocol as presently defined in {{I-D.ietf-quic-transport}} and
-{{I-D.ietf-quic-tls}}, and will change to track those documents.
+This document is focused on the protocol as presently defined in {{!QUIC}} and
+{{!QUIC-TLS}}, and will change to track those documents.
 
 ## QUIC Packet Header Structure {#public-header}
 
-The QUIC packet header is under active development; see section 5 of {{I-D.ietf-quic-transport}} for the present header structure.
+The QUIC packet header is under active development; see section 5 of {{!QUIC}}
+for the present header structure.
 
-The first bit of the QUIC header indicates the present of a long header that exposes more information than 
-the short header. The long header is typically used during connection start or for other control processes while the short header will be used on most data packets to limited unnecessary header overhead. The fields and location of these fields as defined by the current version of QUIC for the long header are fixed for all future version as well. However, note that future versions of QUIC may provide additional fields. In the current version of quic the long header for all header types has a fixed length, containing, besides the Header Form bit, a 7-bit header Type, a 64-bit Connection ID, a 32-bit Packet Number, and a 32-bit Version. The short header is variable length where bits after the Header Form bit indicate the present on the Connection ID, and the length of the packet number. 
+The first bit of the QUIC header indicates the present of a long header that
+exposes more information than the short header. The long header is typically
+used during connection start or for other control processes while the short
+header will be used on most data packets to limited unnecessary header overhead.
+The fields and location of these fields as defined by the current version of
+QUIC for the long header are fixed for all future version as well. However, note
+that future versions of QUIC may provide additional fields. In the current
+version of quic the long header for all header types has a fixed length,
+containing, besides the Header Form bit, a 7-bit header Type, a 64-bit
+Connection ID, a 32-bit Packet Number, and a 32-bit Version. The short header is
+variable length where bits after the Header Form bit indicate the present on the
+Connection ID, and the length of the packet number.
 
 The following information may be exposed in the packet header:
 
-- header type: the long header has a 7-bit header type field following the Header Form bit. The current version of QUIC defines 7 header types, namely Version Negotiation, Client Initial, Server Stateless Retry, Server Cleartext, Client Cleartext, 0-RTT Protected, 1-RTT Protected (key phase 0), 1-RTT Protected (key phase 1), and Public Reset. 
+- header type: the long header has a 7-bit header type field following the
+  Header Form bit. The current version of QUIC defines 7 header types, namely
+  Version Negotiation, Client Initial, Server Stateless Retry, Server Cleartext,
+  Client Cleartext, 0-RTT Protected, 1-RTT Protected (key phase 0), 1-RTT
+  Protected (key phase 1), and Public Reset.
 
 - connection ID: The connection ID is always present on the long and optionally
   present on the short header indicated by the Connection ID Flag. If present at
@@ -147,22 +158,36 @@ The following information may be exposed in the packet header:
   sending endpoint to revise its decision about exposing the Connection ID at
   any time during the connection.
 
-- packet number: Every packet has an associated packet number. The packet number increases with each packet, and the least-significant bits of the packet number are present on each packet. In the short header the length of the exposed packet number field is defined by the (short) header type and can either be 8, 16, or 32 bits. See {{packetnumber}}.
+- packet number: Every packet has an associated packet number. The packet number
+  increases with each packet, and the least-significant bits of the packet
+  number are present on each packet. In the short header the length of the
+  exposed packet number field is defined by the (short) header type and can
+  either be 8, 16, or 32 bits. See {{packetnumber}}.
 
-- version number: The version number is present on the long headers and identifies the version used for that packet, expect for the Version negotiation packet. The version negotiation packet is fixed for all version of QUIC and contains a lit of versions that is supported by the sender. However the version in the version field of the header is the reflected version of the clients initial packet and is therefore explicitly not supported by the sender.
+- version number: The version number is present on the long headers and
+  identifies the version used for that packet, expect for the Version
+  negotiation packet. The version negotiation packet is fixed for all version of
+  QUIC and contains a lit of versions that is supported by the sender. However
+  the version in the version field of the header is the reflected version of the
+  clients initial packet and is therefore explicitly not supported by the
+  sender.
 
-- key phase: The short header further has a Key Phase flag that is used by the endpoint identify the right key that was used to encrypt the packet. Different key phases are indicated with the use of the long header by using to different header types for protected long header packets.
+- key phase: The short header further has a Key Phase flag that is used by the
+  endpoint identify the right key that was used to encrypt the packet. Different
+  key phases are indicated with the use of the long header by using to different
+  header types for protected long header packets.
 
 ## Integrity Protection of the Wire Image {#wire-integrity}
 
-As soon as the cryptographic context is established, 
-all information in the QUIC header, including those exposed in the packet header, is
-integrity protected. Further, information that were sent and exposed in previous packets 
-when the cryptographic context was established yet, e.g. for the cryptographic initial handshake itself,
-will be validate later during the cryptographic handshake, such as the version number.
-Therefore, devices on path MUST NOT change any information or bits in QUIC packet
-headers. As alteration of header information would cause packet drop due to a
-failed integrity check at the receiver, or can even lead to connection termination.
+As soon as the cryptographic context is established, all information in the QUIC
+header, including those exposed in the packet header, is integrity protected.
+Further, information that were sent and exposed in previous packets when the
+cryptographic context was established yet, e.g. for the cryptographic initial
+handshake itself, will be validate later during the cryptographic handshake,
+such as the version number.  Therefore, devices on path MUST NOT change any
+information or bits in QUIC packet headers. As alteration of header information
+would cause packet drop due to a failed integrity check at the receiver, or can
+even lead to connection termination.
 
 ## Connection ID and Rebinding {#rebinding}
 
@@ -175,8 +200,8 @@ during connection establishment, and a server might provide additional
 connection IDs that can the used by the client at any time during the
 connection. Therefore if a flow changes one of its IP addresses it may keep the
 same connection ID, or the connection ID may also change together with the IP
-address migration, avoiding linkability; see section 7.6 of
-{{I-D.ietf-quic-transport}}.
+address migration, avoiding linkability; see Section 7.6 of
+{{!QUIC}}.
 
 ## Packet Numbers {#packetnumber}
 
@@ -189,8 +214,8 @@ connection.
 Unlike TCP sequence numbers, this packet number increases with every packet,
 including those containing only acknowledgment or other control information.
 Indeed, whether a packet contains user data or only control information is
-intentionally left unexposed to the network. The packet number increases with every packet
-but they sender may skip packet numbers.
+intentionally left unexposed to the network. The packet number increases with
+every packet but they sender may skip packet numbers.
 
 While loss detection in QUIC is based on packet numbers, congestion
 control by default provides richer information than vanilla TCP does.
@@ -199,17 +224,23 @@ packet re-ordering.
 
 ## Initial Handshake and PMTUD
 
-[Editor's note: text needed.]
+\[Editor's note: text needed.]
 
 ## Version Negotiation and Greasing
 
-Version negotiation is not protected, given the used protection mechanism can change with the version.
-However, the choices provided in the list of version in the Version Negotiation packet will be validated
-as soon as the cryptographic context has been established. Therefore any manipulation of this list
-will be detected and will cause the endpoints to terminate the connection.
+Version negotiation is not protected, given the used protection mechanism can
+change with the version.  However, the choices provided in the list of version
+in the Version Negotiation packet will be validated as soon as the cryptographic
+context has been established. Therefore any manipulation of this list will be
+detected and will cause the endpoints to terminate the connection.
 
-Also note that the list of versions in the Version Negotiation packet may contain reserved versions. This mechanism is
-used to avoid ossification in the implementation on the selection mechanism. Further, a client may send a Initial Client packet with a reserved version number to trigger version negotiation. In the Version Negotiation packet the connection ID and packet number of the Client Initial packet are reflected to provide a proof of return-routability. Therefore changing these information will also cause the connection to fail.
+Also note that the list of versions in the Version Negotiation packet may
+contain reserved versions. This mechanism is used to avoid ossification in the
+implementation on the selection mechanism. Further, a client may send a Initial
+Client packet with a reserved version number to trigger version negotiation. In
+the Version Negotiation packet the connection ID and packet number of the Client
+Initial packet are reflected to provide a proof of return-routability. Therefore
+changing these information will also cause the connection to fail.
 
 # Specific Network Management Tasks
 
@@ -219,7 +250,7 @@ techniques and how QUIC's design impacts them.
 ## Stateful Treatment of QUIC Traffic {#statefulness}
 
 Stateful network devices such as firewalls use exposed header information to
-support state setup and tear-down. {{I-D.trammell-plus-statefulness}} provides a
+support state setup and tear-down. {{?STATEFULNESS}} provides a
 general model for in-network state management on these devices, independent of
 transport protocol. Features already present in QUIC may be used for state
 maintenance in this model. Here, there are two important goals: distinguishing
@@ -227,11 +258,11 @@ valid QUIC connection establishment from other traffic, in order to establish
 state; and determining the end of a QUIC connection, in order to tear that state
 down.
 
-Both, 1-RTT and O-RTT connection establishment, using a TLS handshake on stream 0, is detectable
-using heuristics similar to those used to detect TLS over TCP. 0-RTT connection
-may additional also send data packets, right after the client hello. These data may be
-reorder in the network, therefore it may be possible that 0-RTT Protected data packet are 
-seen before the Client Initial packet.
+Both, 1-RTT and O-RTT connection establishment, using a TLS handshake on stream
+0, is detectable using heuristics similar to those used to detect TLS over TCP.
+0-RTT connection may additional also send data packets, right after the client
+hello. These data may be reorder in the network, therefore it may be possible
+that 0-RTT Protected data packet are seen before the Client Initial packet.
 
 Exposure of connection shutdown is currently under discussion; see
 https://github.com/quicwg/base-drafts/issues/353 and
@@ -251,8 +282,9 @@ loss between an observation point and the receiver cannot be reliably estimated.
 The lack of any acknowledgement information or timestamping information in the
 QUIC packet header makes running passive estimation of latency via round trip
 time (RTT) impossible. RTT can only be measured at connection establishment
-time, by observing the Client Initial packet and the Server's reply to this packet which
-maybe a Server Cleartext, Version Negotiation, or Server Stateless Retry packet.
+time, by observing the Client Initial packet and the Server's reply to this
+packet which maybe a Server Cleartext, Version Negotiation, or Server Stateless
+Retry packet.
 
 Note that adding a packet number echo (as in
 https://github.com/quicwg/base-drafts/pull/367 or
@@ -275,50 +307,53 @@ For enterprises and network operators one of the biggest management challenges
 is dealing with Distributed Denial of Service (DDoS) attacks. Some network
 operators offer Security as a Service (SaaS) solutions that detect attacks by
 monitoring, analyzing and filtering traffic. These approaches generally utilize
-network flow data {{RFC7011}}. If any flows pose a threat, usually they are
+network flow data {{?RFC7011}}. If any flows pose a threat, usually they are
 routed to a "scrubbing environment" where the traffic is filtered, allowing the
 remaining "good" traffic to continue to the customer environment.
 
 This type of DDoS mitigation is fundamentally based on tracking state for flows
-(see {{statefulness}}) that have receiver confirmation and a proof of return-routability, 
-and classifying flows as legitimate or DoS traffic. The
-QUIC packet header currently does not support an explicit mechanism to 
-easily distinguish legitimate QUIC traffic from other UDP traffic. However,
-the first packet in a QUIC connection will usually be a Client Initial packet. 
-This can be used to identify the first packet of the connection.
+(see {{statefulness}}) that have receiver confirmation and a proof of
+return-routability, and classifying flows as legitimate or DoS traffic. The QUIC
+packet header currently does not support an explicit mechanism to easily
+distinguish legitimate QUIC traffic from other UDP traffic. However, the first
+packet in a QUIC connection will usually be a Client Initial packet.  This can
+be used to identify the first packet of the connection.
 
-If the QUIC handshake was not observed by the defense system, 
-the connection ID can be used as a confirmation signal as per
-{{I-D.trammell-plus-statefulness}} if present in both directions. 
+If the QUIC handshake was not observed by the defense system, the connection ID
+can be used as a confirmation signal as per
+{{?STATEFULNESS=I-D.trammell-plus-statefulness}} if present in both directions.
 
 Further, the use of a connection ID to support connection migration renders
-5-tuple based filtering insufficient, and requires more state to be maintained by
-DDoS defense systems. However, it is questionable if connection migrations needs to be
-supported in a DDOS attack. If the connection migration is not visible to the network 
-that performs the DDoS detection, an active, migrated QUIC connection may be blocked 
-by such a system under attack. However, a defense system might simply rely on the fast
-resumption mechanism provided by QUIC. This problem is also related to these issues under 
-discussion: https://github.com/quicwg/base-drafts/issues/203 
+5-tuple based filtering insufficient, and requires more state to be maintained
+by DDoS defense systems. However, it is questionable if connection migrations
+needs to be supported in a DDOS attack. If the connection migration is not
+visible to the network that performs the DDoS detection, an active, migrated
+QUIC connection may be blocked by such a system under attack. However, a defense
+system might simply rely on the fast resumption mechanism provided by QUIC. This
+problem is also related to these issues under discussion:
+https://github.com/quicwg/base-drafts/issues/203
 
 ## QoS support and ECMP
 
-QUIC does not provide any additional information on requirements on Quality of Service (QoS)
-provided from the network. QUIC assumes that all packets with the same 5-tuple 
-{dest addr, source addr, protocol, dest port, source port} will receive similar network treatment.
-That means all stream that are multiplexed over the same QUIC connection require the 
-same network treatment and are handled by the same congestion controller. If 
-differential network treatment is desired, multiple QUIC connection to the same server might
-be used, given that establishing a new connection using 0-RTT support is cheap and fast.
+QUIC does not provide any additional information on requirements on Quality of
+Service (QoS) provided from the network. QUIC assumes that all packets with the
+same 5-tuple {dest addr, source addr, protocol, dest port, source port} will
+receive similar network treatment.  That means all stream that are multiplexed
+over the same QUIC connection require the same network treatment and are handled
+by the same congestion controller. If differential network treatment is desired,
+multiple QUIC connection to the same server might be used, given that
+establishing a new connection using 0-RTT support is cheap and fast.
 
-QoS mechanisms in the network MAY also use the connection ID for service differentiation 
-as usually a change of connection ID is bind to a change of address which anyway is likely to
-lead to a re-route on a different path with different network characteristics. 
+QoS mechanisms in the network MAY also use the connection ID for service
+differentiation as usually a change of connection ID is bind to a change of
+address which anyway is likely to lead to a re-route on a different path with
+different network characteristics.
 
-Given that QUIC is more tolerant of packet re-ordering than TCP (see {{packetnumber}}), 
-Equal-cost multi-path routing (ECMP) does not necessarily need to be flow based. 
-However, 5-tuple (plus eventually connection ID if present) 
-matching is still beneficial for QoS given all packets are handled by the same
-congestion controller.
+Given that QUIC is more tolerant of packet re-ordering than TCP (see
+{{packetnumber}}), Equal-cost multi-path routing (ECMP) does not necessarily
+need to be flow based.  However, 5-tuple (plus eventually connection ID if
+present) matching is still beneficial for QoS given all packets are handled by
+the same congestion controller.
 
 ## Load Balancing using the Connection ID {#loadbalancing}
 
@@ -328,11 +363,11 @@ pools of back-end servers, fronted by load balancing systems.  These load
 balancers are responsible for identifying the most appropriate server for each
 connection and for routing all packets belonging to that connection to the
 chosen server.
- 
+
 Load balancers are often deployed in pools for redundancy and load sharing. For
 high availability, it is important that when packets belonging to a flow start
 to arrive at a different load balancer in the load balancer pool, the packets
-continue to be forwarded to the original server in the server pool. 
+continue to be forwarded to the original server in the server pool.
 
 Support for seamless connection migration is an important design goal of QUIC
 – a necessity due to the proliferation of mobile connected devices. This
@@ -348,7 +383,7 @@ and would not be able to route it back to the original POP.
 Load balancers may cooperate with servers or server pools behind them to use a
 server-generated Connection ID value, in order to support stateless load
 balancing, even across NAT rebinding or other address change events (see
-{{rebinding}}). See section 5.7 of {{I-D.ietf-quic-transport}}.
+{{rebinding}}). See section 5.7 of {{!QUIC}}.
 
 Server-generated Connection IDs must not encode any information other that that
 needed to route packets to the appropriate backend server(s): typically the
@@ -361,13 +396,11 @@ that allows bad actors to direct traffic at a specific backend server or pool.
 It is therefore recommended that Server-Generated Connection ID includes a
 cryptographic MAC that the load balancer pool server are able to identify and
 discard packets featuring an invalid MAC.
- 
-
 
 
 # IANA Considerations
 
-This document has no actions for IANA. 
+This document has no actions for IANA.
 
 # Security Considerations
 
@@ -386,7 +419,7 @@ operate through the deep packet inspection (DPI) of application-layer headers
 are directly antithetical to QUIC's goal to provide confidentiality to its
 application-layer protocol(s); in these cases, alternatives must be found.
 
-# Contributors 
+# Contributors
 
 Igor Lubashev contributed text to {{loadbalancing}} on the use of the connection
 ID for load balancing.


### PR DESCRIPTION
This brings the ops drafts into line with the base ones.  The configuration (circle.yml, Makefile, .editorconfig) is copied over.

I removed trailing whitespace from the drafts and reflowed paragraphs.

I changed the references so that they are a little cleaner.  Other than the reflow, I didn't touch the text, other than to change "section" to "Section" where I noticed some errors.