### PR TITLE
DDoS mitigations - linking after NAT rebinding and UDP Policing

### DIFF
--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -744,6 +744,23 @@ performs the DDoS detection, an active, migrated QUIC connection may be
 blocked by such a system under attack. However, a defense system might simply
 rely on the fast resumption mechanism provided by QUIC.
 
+### UDP Policing
+
+UDP is the most prevalent DDoS vector, since it is easy for compromised
+non-admin applications to send a flood of large UDP packets (while with TCP the
+attacker gets throttled by the congestion controller). Networks should be
+prepared for UDP flood attacks that masquerade as QUIC traffic.
+
+If attack classification fails, a possible response is to police UDP traffic on
+the network, allocating a fixed portion of the network capacity to UDP. Blindly
+blocking a significant fraction of QUIC packets will allow many QUIC handshakes
+to complete, preventing a TCP failover, but the connections will suffer a severe
+packet loss. As long as all QUIC-capable applications can failover to TCP (at
+least applications using well-known UDP ports), the recommended way to drop QUIC
+packets is to either drop them all or to police them based on the hash of the
+UDP datagram's source and destination addresses, blocking a portion of the hash
+space that corresponds to the fraction of UDP traffic one wishes to drop.
+
 ## Distinguishing acknowledgment traffic
 
 Some deployed in-network functions distinguish pure-acknowledgment (ACK) packets

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -733,16 +733,22 @@ tracking of QUIC traffic as in {{sec-stateful}} above can be used in this
 classification step.
 
 Note that the use of a connection ID to support connection migration renders
-5-tuple based filtering insufficient, and requires more state to be maintained
-by DDoS defense systems, and linkability resistance in connection ID update
-mechanisms means that a connection ID aware DDoS defense system must have the
-same information about flows as the load balancer.
+5-tuple based filtering insufficient and requires more state to be maintained by
+DDoS defense systems. For the common case of NAT rebinding, DDoS defense systems
+can detect a change in client's endpoint address by linking flows based on the
+first 8 bytes of the server's connection IDs, provided the server is using at
+least 8-bytes-long connection IDs. QUIC's linkability resistance ensures that a
+deliberate connection migration is accompanied by a change in the connection ID
+and necessitate that connection ID aware DDoS defense system must have the same
+information about connection IDs as the load balancer.
 
-However, it is questionable if connection migrations needs to be supported in
-a DDOS attack. If the connection migration is not visible to the network that
-performs the DDoS detection, an active, migrated QUIC connection may be
-blocked by such a system under attack. However, a defense system might simply
-rely on the fast resumption mechanism provided by QUIC.
+It is questionable if connection migrations must be supported during a DDoS
+attack. If the connection migration is not visible to the network that performs
+the DDoS detection, an active, migrated QUIC connection may be blocked by such a
+system under attack. As soon as the connection blocking is detected by the
+client, the client may rely on the fast resumption mechanism provided by
+QUIC. When clients migrate to a new path, they should be prepared for the
+migration to fail and attempt to reconnect quickly.
 
 ### UDP Policing
 


### PR DESCRIPTION
This PR describes how a stateful DDoS system may link flows after a NAT rebinding event.

Also, the PR adds a section on how to police QUIC packets to minimize disruption to application that are able to failover to TCP.  Namely, avoid blocking a random fraction of UDP packets and, instead, focus on either blocking all packets from a subset of users or none at all.

This is related to areas discussed in #93.