### PR TITLE
Minor update on initial encryption wording

### DIFF
--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -351,8 +351,8 @@ packet in a coalesced packet.
 {: #fig-server-hello title="Typical QUIC Server Hello datagram pattern"}
 
 The Server Hello datagram also exposes version number, source and
-destination connection IDs and information in the TLS Server Hello message is
-obfuscated using the Initial secrect.
+destination connection IDs and information in the TLS Server Hello message
+which is obfuscated using the Initial secrect.
 
 ~~~~~
 +------------------------------------------------------------+

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -352,7 +352,7 @@ packet in a coalesced packet.
 
 The Server Hello datagram also exposes version number, source and
 destination connection IDs and information in the TLS Server Hello message
-which is obfuscated using the Initial secrect.
+which is obfuscated using the Initial secret.
 
 ~~~~~
 +------------------------------------------------------------+

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -324,8 +324,8 @@ including any TLS Server Name Indication (SNI) present, is obfuscated using the
 Initial secrect. The QUIC PADDING frame shown here may be present to ensure the
 Client Hello datagram has a minimum size of 1200 octets, to mitigate the
 possibility of handshake amplification. Note that the location of PADDING is
-implementation-dependent, and PADDING frames may not appear in the Initial packet
-in a coalesced packet.
+implementation-dependent, and PADDING frames may not appear in the Initial
+packet in a coalesced packet.
 
 ~~~~~
 +------------------------------------------------------------+

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -319,12 +319,13 @@ finishing the transmission of CRYPTO frames.
 {: #fig-client-hello title="Typical 1-RTT QUIC Client Hello datagram pattern"}
 
 The Client Hello datagram exposes version number, source and destination
-connection IDs, and information in the TLS Client Hello message, including any
-TLS Server Name Indication (SNI) present, in the clear. The QUIC PADDING frame
-shown here may be present to ensure the Client Hello datagram has a minimum size
-of 1200 octets, to mitigate the possibility of handshake amplification. Note
-that the location of PADDING is implementation-dependent, and PADDING frames may
-not appear in the Initial packet in a coalesced packet.
+connection IDs in the clear. Information in the TLS Client Hello frame,
+including any TLS Server Name Indication (SNI) present, is obfuscated using the
+Initial secrect. The QUIC PADDING frame shown here may be present to ensure the
+Client Hello datagram has a minimum size of 1200 octets, to mitigate the
+possibility of handshake amplification. Note that the location of PADDING is
+implementation-dependent, and PADDING frames may not appear in the Initial packet
+in a coalesced packet.
 
 ~~~~~
 +------------------------------------------------------------+
@@ -349,8 +350,9 @@ not appear in the Initial packet in a coalesced packet.
 ~~~~~
 {: #fig-server-hello title="Typical QUIC Server Hello datagram pattern"}
 
-The Server Hello datagram exposes version number, source and destination
-connection IDs, and information in the TLS Server Hello message.
+The Server Hello datagram also exposes version number, source and
+destination connection IDs and information in the TLS Server Hello message is
+obfuscated using the Initial secrect.
 
 ~~~~~
 +------------------------------------------------------------+

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -321,7 +321,7 @@ finishing the transmission of CRYPTO frames.
 The Client Hello datagram exposes version number, source and destination
 connection IDs in the clear. Information in the TLS Client Hello frame,
 including any TLS Server Name Indication (SNI) present, is obfuscated using the
-Initial secrect. The QUIC PADDING frame shown here may be present to ensure the
+Initial secret. The QUIC PADDING frame shown here may be present to ensure the
 Client Hello datagram has a minimum size of 1200 octets, to mitigate the
 possibility of handshake amplification. Note that the location of PADDING is
 implementation-dependent, and PADDING frames may not appear in the Initial


### PR DESCRIPTION
However, we also use the terms Server/Client Hello datagram to cover all QUIC Packets of the first two datagrams sent. This term is not used in the transport draft (anymore) and I find it confusing given the TLS terminology. Should we maybe use a different term?