### PR TITLE
New section on SNI parsing and appendix on Google QUIC

### DIFF
--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -938,6 +938,9 @@ This section contains algorithms that allows parsing versions from both
 Google QUIC and IETF QUIC. These mechanisms will become
 irrelevant when IETF QUIC is fully deployed and Google QUIC is deprecated.
 
+Note that other than this appendix, nothing in this document applies to
+Google QUIC.
+
 Conceptually, a Google QUIC version is an opaque 32bit field. When we refer to a
 version with four printable characters, we use its ASCII representation:
 for example, Q050 refers to \{'Q', '0', '5', '0'\} which is equal to

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -930,8 +930,8 @@ irrelevant when IETF QUIC is fully deployed and Google QUIC is deprecated.
 
 Conceptually, a Google QUIC version is an opaque 32bit field. When we refer to a
 version with four printable characters, we use its ASCII representation:
-for example, Q050 refers to {'Q', '0', '5', '0'} which is equal to
-{0x51, 0x30, 0x35, 0x30}. Otherwise, we use its hexadecimal representation:
+for example, Q050 refers to \{'Q', '0', '5', '0'\} which is equal to
+\{0x51, 0x30, 0x35, 0x30\}. Otherwise, we use its hexadecimal representation:
 for example, 0xff00001d refers to {0xff, 0x00, 0x00, 0x1d}.
 
 QUIC versions that start with 'Q' or 'T' followed by three digits are 
@@ -941,9 +941,9 @@ Versions Q046, Q050, T050, and T051 are not fully documented, but this appendix
 should contain enough information to allow parsing Client Hellos for those versions.
 
 This appendis uses the following conventions:
-array[i] – one byte at index i of array
-array[i:j] – subset of array starting with index i (inclusive) up to j-1 (inclusive)
-array[i:] – subset of array starting with index i (inclusive) up to the end of the array
+array\[i\] – one byte at index i of array
+array\[i:j\] – subset of array starting with index i (inclusive) up to j-1 (inclusive)
+array\[i:\] – subset of array starting with index i (inclusive) up to the end of the array
 
 ### Distinguishing IETF QUIC and Google QUIC Versions
 

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -589,7 +589,7 @@ Work is currently underway in the TLS working group to encrypt the SNI in TLS
 would make SNI-based application identification impossible through passive
 measurement.
 
-### Extracting the Server Name Indication (SNI) information
+### Extracting Server Name Indication (SNI) Information
 
 If the SNI is not encrypted it can be derived form the QUIC Initial packet 
 by calculating the Initial Secret to decrypt the packet payload and parse the 
@@ -603,7 +603,7 @@ the QUIC packet is set to 1, indicating a long header.
 
 Note, that proprietary QUIC versions, that have been deployed before standardization,
 might not set the first bit in a QUIC long header packets to 1. To parse these
-versions example code is provided in the appendix (see {{#sec-google-version}}),
+versions example code is provided in the appendix (see {{sec-google-version}}),
 however, it is expected that these versions will gradually disappear over time.
 
 When the version has been identified as QUIC version 1, the packet type needs to be

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -939,7 +939,7 @@ Google QUIC and IETF QUIC. These mechanisms will become
 irrelevant when IETF QUIC is fully deployed and Google QUIC is deprecated.
 
 Note that other than this appendix, nothing in this document applies to
-Google QUIC. And the purpose of this appendix is merely to distinguish IETF QUIC 
+Google QUIC. And the purpose of this appendix is merely to distinguish IETF QUIC
 from any versions of Google QUIC.
 
 Conceptually, a Google QUIC version is an opaque 32bit field. When we refer to a

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -618,10 +618,11 @@ connection ID itself.
 To determine the end of the header and find the start of the payload further
 the packet number length, the source connection ID length, as well as the token
 length need to be extracted. The packet number length is defined by the seventh
-and eight bits of the header as described in section 17.2. of {{QUIC-TRANSPORT}}.
-The source connection ID length is specified in the byte after the destination
-connection ID. And the token length, which follows the source connection ID,
-is a variable length integer as specified in section 16 of {{QUIC-TRANSPORT}}.
+and eight bits of the header as described in section 17.2. of
+{{QUIC-TRANSPORT}}. The source connection ID length is specified in the byte
+after the destination connection ID. And the token length, which follows the
+source connection ID, is a variable length integer as specified in section 16
+of {{QUIC-TRANSPORT}}.
 
 Finally after decryption, the Initial Client packet can be parsed to detect the
 CRYPTO frame that contains the TLS Client Hello, which then can be respectively

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -591,15 +591,15 @@ measurement.
 
 ### Extracting Server Name Indication (SNI) Information
 
-If the SNI is not encrypted it can be derived from the QUIC Initial packet 
-by calculating the Initial Secret to decrypt the packet payload and parse the 
+If the SNI is not encrypted it can be derived from the QUIC Initial packet
+by calculating the Initial Secret to decrypt the packet payload and parse the
 QUIC CRYPTO Frame containing the TLS ClientHello.
 
 As both the initial salt for the Initial Secret as well as CRYPTO frame itself
 are version-specific, the first step is always to parse the version number
 (second to sixth byte of the long header). Note that only long header packets
 carry the version number, so it is necessary to also check the if first bit of
-the QUIC packet is set to 1, indicating a long header. 
+the QUIC packet is set to 1, indicating a long header.
 
 Note, that proprietary QUIC versions, that have been deployed before standardization,
 might not set the first bit in a QUIC long header packets to 1. To parse these
@@ -626,8 +626,8 @@ Finally after decryption, the Initial Client packet can be parsed to detect the
 CRYPTO frame that contains the TLS Client Hello, which then can be respectively
 parsed similar as for all other TLS connections. The Initial client packet may
 contain other frames, so the first byte of each frame need to be checked to identify
-the frame type and the skip over the frame. Note that the length of the frames is 
-dependent on the frame type. Usually for QUIC version 1, the packet is expected 
+the frame type and the skip over the frame. Note that the length of the frames is
+dependent on the frame type. Usually for QUIC version 1, the packet is expected
 to only carry the CRYPTO frame and optionally padding frames. However, padding
 which is one byte of zeros, may also occur before or after the CRYPTO frame.
 
@@ -907,12 +907,12 @@ security-relevant.
 
 Dan Druta contributed text to {{sec-ddos-dec}}. Igor Lubashev contributed text
 to {{sec-loadbalancing}} on the use of the connection ID for load balancing.
-Marcus Ilhar contributed text to {{sec-rtt}} on the use of the spin bit. The 
+Marcus Ilhar contributed text to {{sec-rtt}} on the use of the spin bit. The
 pseudo provided in the appendix is based on input provided by David Schinazi.
 
 # Acknowledgments
 
-Thanks to Martin Thomson and Martin Duke for contributing by reviewing and 
+Thanks to Martin Thomson and Martin Duke for contributing by reviewing and
 providing text proposals.
 
 This work is partially supported by the European Commission under Horizon 2020
@@ -920,7 +920,7 @@ grant agreement no. 688421 Measurement and Architecture for a Middleboxed
 Internet (MAMI), and by the Swiss State Secretariat for Education, Research, and
 Innovation under contract no. 15.0268. This support does not imply endorsement.
 
-# Appendix 
+# Appendix
 
 This appendix uses the following conventions:
 array\[i\] – one byte at index i of array
@@ -939,7 +939,7 @@ for example, Q050 refers to \{'Q', '0', '5', '0'\} which is equal to
 \{0x51, 0x30, 0x35, 0x30\}. Otherwise, we use its hexadecimal representation:
 for example, 0xff00001d refers to {0xff, 0x00, 0x00, 0x1d}.
 
-QUIC versions that start with 'Q' or 'T' followed by three digits are 
+QUIC versions that start with 'Q' or 'T' followed by three digits are
 Google QUIC versions. Versions up to and including 43 are documented by
 <https://docs.google.com/document/d/1WJvyZflAO2pq77yOLbp9NsGjC1CHetAXV8I0fQe-B_U/preview>.
 Versions Q046, Q050, T050, and T051 are not fully documented, but this appendix
@@ -983,7 +983,7 @@ the QUIC packet, in other words the first byte of the UDP payload.
   }
   first_nonzero_payload_byte = payload[counter]
   fnz_payload_byte_bit3 = ((first_nonzero_payload_byte & 0x20) != 0)
- 
+
   if (first_nonzero_payload_byte != 0x06) {
     abort("Unexpected frame")
   }

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -601,18 +601,19 @@ are version-specific, the first step is always to parse the version number
 carry the version number, so it is necessary to also check the if first bit of
 the QUIC packet is set to 1, indicating a long header.
 
-Note, that proprietary QUIC versions, that have been deployed before standardization,
-might not set the first bit in a QUIC long header packets to 1. To parse these
-versions example code is provided in the appendix (see {{sec-google-version}}),
-however, it is expected that these versions will gradually disappear over time.
+Note, that proprietary QUIC versions, that have been deployed before
+standardization, might not set the first bit in a QUIC long header packets to
+1. To parse these versions example code is provided in the appendix (see
+{{sec-google-version}}), however, it is expected that these versions will
+gradually disappear over time.
 
-When the version has been identified as QUIC version 1, the packet type needs to be
-verified as an Initial packet by checking that the third and fourth bit of the header
-are both set to 0. Then the Client Destination Connection ID
-needs to be extracted to calculate the Initial Secret together with
-the version specific initial salt, as described in {{QUIC-TLS}}. The length of the
-connection ID is indicated in the 6th byte of the header followed by the connection
-ID itself.
+When the version has been identified as QUIC version 1, the packet type needs
+to be verified as an Initial packet by checking that the third and fourth bit
+of the header are both set to 0. Then the Client Destination Connection ID
+needs to be extracted to calculate the Initial Secret together with the
+version specific initial salt, as described in {{QUIC-TLS}}. The length of
+the connection ID is indicated in the 6th byte of the header followed by the
+connection ID itself.
 
 To determine the end of the header and find the start of the payload further
 the packet number length, the source connection ID length, as well as the token
@@ -625,11 +626,12 @@ is a variable length integer as specified in section 16 of {{QUIC-TRANSPORT}}.
 Finally after decryption, the Initial Client packet can be parsed to detect the
 CRYPTO frame that contains the TLS Client Hello, which then can be respectively
 parsed similar as for all other TLS connections. The Initial client packet may
-contain other frames, so the first byte of each frame need to be checked to identify
-the frame type and the skip over the frame. Note that the length of the frames is
-dependent on the frame type. Usually for QUIC version 1, the packet is expected
-to only carry the CRYPTO frame and optionally padding frames. However, padding
-which is one byte of zeros, may also occur before or after the CRYPTO frame.
+contain other frames, so the first byte of each frame need to be checked to
+identify the frame type and the skip over the frame. Note that the length of the
+frames is dependent on the frame type. Usually for QUIC version 1, the packet is
+expected to only carry the CRYPTO frame and optionally padding frames. However,
+padding which is one byte of zeros, may also occur before or after the CRYPTO
+frame.
 
 ## Flow association {#sec-flow-association}
 
@@ -924,8 +926,10 @@ Innovation under contract no. 15.0268. This support does not imply endorsement.
 
 This appendix uses the following conventions:
 array\[i\] – one byte at index i of array
-array\[i:j\] – subset of array starting with index i (inclusive) up to j-1 (inclusive)
-array\[i:\] – subset of array starting with index i (inclusive) up to the end of the array
+array\[i:j\] – subset of array starting with index i (inclusive) up to j-1
+(inclusive)
+array\[i:\] – subset of array starting with index i (inclusive) up to the
+end of the array
 
 ## Distinguishing IETF QUIC and Google QUIC Versions {#sec-google-version}
 
@@ -941,9 +945,11 @@ for example, 0xff00001d refers to {0xff, 0x00, 0x00, 0x1d}.
 
 QUIC versions that start with 'Q' or 'T' followed by three digits are
 Google QUIC versions. Versions up to and including 43 are documented by
-<https://docs.google.com/document/d/1WJvyZflAO2pq77yOLbp9NsGjC1CHetAXV8I0fQe-B_U/preview>.
+<https://docs.google.com/document/d/
+1WJvyZflAO2pq77yOLbp9NsGjC1CHetAXV8I0fQe-B_U/preview>.
 Versions Q046, Q050, T050, and T051 are not fully documented, but this appendix
-should contain enough information to allow parsing Client Hellos for those versions.
+should contain enough information to allow parsing Client Hellos for those
+versions.
 
 To extract the version number itself, one needs to look at the first byte of
 the QUIC packet, in other words the first byte of the UDP payload.

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -591,9 +591,9 @@ measurement.
 
 ### Extracting Server Name Indication (SNI) Information
 
-If the SNI is not encrypted it can be derived form the QUIC Initial packet 
+If the SNI is not encrypted it can be derived from the QUIC Initial packet 
 by calculating the Initial Secret to decrypt the packet payload and parse the 
-QUIC CRYPTO Frame with the TLS ClientHello.
+QUIC CRYPTO Frame containing the TLS ClientHello.
 
 As both the initial salt for the Initial Secret as well as CRYPTO frame itself
 are version-specific, the first step is always to parse the version number
@@ -627,9 +627,9 @@ CRYPTO frame that contains the TLS Client Hello, which then can be respectively
 parsed similar as for all other TLS connections. The Initial client packet may
 contain other frames, so the first byte of each frame need to be checked to identify
 the frame type and the skip over the frame. Note that the length of the frames is 
-depended on the frame type. Usually for QUIC version 1, the packet is expected 
+dependent on the frame type. Usually for QUIC version 1, the packet is expected 
 to only carry the CRYPTO frame and optionally padding frames. However, padding
-which is one byte of zeros, may occur after or also before the CRYPO frame.
+which is one byte of zeros, may also occur before or after the CRYPTO frame.
 
 ## Flow association {#sec-flow-association}
 
@@ -940,7 +940,7 @@ Google QUIC versions. Versions up to and including 43 are documented by
 Versions Q046, Q050, T050, and T051 are not fully documented, but this appendix
 should contain enough information to allow parsing Client Hellos for those versions.
 
-This appendis uses the following conventions:
+This appendix uses the following conventions:
 array\[i\] – one byte at index i of array
 array\[i:j\] – subset of array starting with index i (inclusive) up to j-1 (inclusive)
 array\[i:\] – subset of array starting with index i (inclusive) up to the end of the array

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -603,7 +603,7 @@ the QUIC packet is set to 1, indicating a long header.
 
 Note, that proprietary QUIC versions, that have been deployed before standardization,
 might not set the first bit in a QUIC long header packets to 1. To parse these
-versions example code is provided in the appendix (see {{#sec:google-version}}),
+versions example code is provided in the appendix (see {{#sec-google-version}}),
 however, it is expected that these versions will gradually disappear over time.
 
 When the version has been identified as QUIC version 1, the packet type needs to be
@@ -922,7 +922,7 @@ Innovation under contract no. 15.0268. This support does not imply endorsement.
 
 # Appendix
 
-## Handling of Google QUIC  {#sec:google-version} 
+## Handling of Google QUIC  {#sec-google-version} 
 
 This sections contains algorithms that allows parsing versions from both
 Google QUIC and IETF QUIC. These mechanisms will become

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -934,7 +934,7 @@ end of the array
 
 ## Distinguishing IETF QUIC and Google QUIC Versions {#sec-google-version}
 
-This sections contains algorithms that allows parsing versions from both
+This section contains algorithms that allows parsing versions from both
 Google QUIC and IETF QUIC. These mechanisms will become
 irrelevant when IETF QUIC is fully deployed and Google QUIC is deprecated.
 

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -912,7 +912,7 @@ pseudo provided in the appendix is based on input provided by David Schinazi.
 
 # Acknowledgments
 
-Thanks to Martin Thomas and Martin Duke for contributing by reviewing and 
+Thanks to Martin Thomson and Martin Duke for contributing by reviewing and 
 providing text proposals.
 
 This work is partially supported by the European Commission under Horizon 2020

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -177,7 +177,9 @@ The following information is exposed in QUIC packet headers:
   the version used for that packet. Note that during Version Negotiation (see
   {{version}}, and Section 17.2.1 of {{QUIC-TRANSPORT}}, the version number
   field has a special value (0x00000000) that identifies the packet as a Version
-  Negotiation packet.
+  Negotiation packet. QUIC versions that start with 0xff are IETF drafts. QUIC
+  versions that start with 0x0000 are reserved for IETF consensus documents,
+  for example the QUIC version 1 is expected to use version 0x00000001.
 
 - source and destination connection ID: short and long packet headers carry a
   destination connection ID, a variable-length field that can be used to
@@ -587,6 +589,48 @@ Work is currently underway in the TLS working group to encrypt the SNI in TLS
 would make SNI-based application identification impossible through passive
 measurement.
 
+### Extracting the Server Name Indication (SNI) information
+
+If the SNI is not encrypted it can be derived form the QUIC Initial packet 
+by calculating the Initial Secret to decrypt the packet payload and parse the 
+QUIC CRYPTO Frame with the TLS ClientHello.
+
+As both the initial salt for the Initial Secret as well as CRYPTO frame itself
+are version-specific, the first step is always to parse the version number
+(second to sixth byte of the long header). Note that only long header packets
+carry the version number, so it is necessary to also check the if first bit of
+the QUIC packet is set to 1, indicating a long header. 
+
+Note, that proprietary QUIC versions, that have been deployed before standardization,
+might not set the first bit in a QUIC long header packets to 1. To parse these
+versions example code is provided in the appendix (see {{#sec:google-version}}),
+however, it is expected that these versions will gradually disappear over time.
+
+When the version has been identified as QUIC version 1, the packet type needs to be
+verified as an Initial packet by checking that the third and fourth bit of the header
+are both set to 0. Then the Client Destination Connection ID
+needs to be extracted to calculate the Initial Secret together with
+the version specific initial salt, as described in {{QUIC-TLS}}. The length of the
+connection ID is indicated in the 6th byte of the header followed by the connection
+ID itself.
+
+To determine the end of the header and find the start of the payload further
+the packet number length, the source connection ID length, as well as the token
+length need to be extracted. The packet number length is defined by the seventh
+and eight bits of the header as described in section 17.2. of {{QUIC-TRANSPORT}}.
+The source connection ID length is specified in the byte after the destination
+connection ID. And the token length, which follows the source connection ID,
+is a variable length integer as specified in section 16 of {{QUIC-TRANSPORT}}.
+
+Finally after decryption, the Initial Client packet can be parsed to detect the
+CRYPTO frame that contains the TLS Client Hello, which then can be respectively
+parsed similar as for all other TLS connections. The Initial client packet may
+contain other frames, so the first byte of each frame need to be checked to identify
+the frame type and the skip over the frame. Note that the length of the frames is 
+depended on the frame type. Usually for QUIC version 1, the packet is expected 
+to only carry the CRYPTO frame and optionally padding frames. However, padding
+which is one byte of zeros, may occur after or also before the CRYPO frame.
+
 ## Flow association {#sec-flow-association}
 
 The QUIC Connection ID (see {{rebinding}}) is designed to allow an on-path
@@ -863,11 +907,167 @@ security-relevant.
 
 Dan Druta contributed text to {{sec-ddos-dec}}. Igor Lubashev contributed text
 to {{sec-loadbalancing}} on the use of the connection ID for load balancing.
-Marcus Ilhar contributed text to {{sec-rtt}} on the use of the spin bit.
+Marcus Ilhar contributed text to {{sec-rtt}} on the use of the spin bit. The 
+pseudo provided in the appendix is based on input provided by David Schinazi.
 
 # Acknowledgments
+
+Thanks to Martin Thomas and Martin Duke for contributing by reviewing and 
+providing text proposals.
 
 This work is partially supported by the European Commission under Horizon 2020
 grant agreement no. 688421 Measurement and Architecture for a Middleboxed
 Internet (MAMI), and by the Swiss State Secretariat for Education, Research, and
 Innovation under contract no. 15.0268. This support does not imply endorsement.
+
+# Appendix
+
+## Handling of Google QUIC  {#sec:google-version} 
+
+This sections contains algorithms that allows parsing versions from both
+Google QUIC and IETF QUIC. These mechanisms will become
+irrelevant when IETF QUIC is fully deployed and Google QUIC is deprecated.
+
+Conceptually, a Google QUIC version is an opaque 32bit field. When we refer to a
+version with four printable characters, we use its ASCII representation:
+for example, Q050 refers to {'Q', '0', '5', '0'} which is equal to
+{0x51, 0x30, 0x35, 0x30}. Otherwise, we use its hexadecimal representation:
+for example, 0xff00001d refers to {0xff, 0x00, 0x00, 0x1d}.
+
+QUIC versions that start with 'Q' or 'T' followed by three digits are 
+Google QUIC versions. Versions up to and including 43 are documented by
+<https://docs.google.com/document/d/1WJvyZflAO2pq77yOLbp9NsGjC1CHetAXV8I0fQe-B_U/preview>.
+Versions Q046, Q050, T050, and T051 are not fully documented, but this appendix
+should contain enough information to allow parsing Client Hellos for those versions.
+
+This appendis uses the following conventions:
+array[i] – one byte at index i of array
+array[i:j] – subset of array starting with index i (inclusive) up to j-1 (inclusive)
+array[i:] – subset of array starting with index i (inclusive) up to the end of the array
+
+### Distinguishing IETF QUIC and Google QUIC Versions
+
+To extract the version number itself, one needs to look at the first byte of
+the QUIC packet, in other words the first byte of the UDP payload.
+
+~~~
+  first_byte = packet[0]
+  first_byte_bit1 = ((first_byte & 0x80) != 0)
+  first_byte_bit2 = ((first_byte & 0x40) != 0)
+  first_byte_bit3 = ((first_byte & 0x20) != 0)
+  first_byte_bit4 = ((first_byte & 0x10) != 0)
+  first_byte_bit5 = ((first_byte & 0x08) != 0)
+  first_byte_bit6 = ((first_byte & 0x04) != 0)
+  first_byte_bit7 = ((first_byte & 0x02) != 0)
+  first_byte_bit8 = ((first_byte & 0x01) != 0)
+  if (first_byte_bit1) {
+    version = packet[1:5]
+  } else if (first_byte_bit5 && !first_byte_bit2) {
+    if (!first_byte_bit8) {
+      abort("Packet without version")
+    }
+    if (first_byte_bit5) {
+      version = packet[9:13]
+    } else {
+      version = packet[5:9]
+    }
+  } else {
+    abort("Packet without version")
+  }
+~~~
+
+### Initial salt value for Google versions
+
+Q043 and Q046 do not encrypt the Initial packet.  
+
+~~~
+  if (version == Q050) {
+      initial_salt = {0x50, 0x45, 0x74, 0xef, 0xd0, 0x66, 0xfe,
+                      0x2f, 0x9d, 0x94, 0x5c, 0xfc, 0xdb, 0xd3,
+                      0xa7, 0xf0, 0xd3, 0xb5, 0x6b, 0x45}
+    } else if (version == T050) {
+      initial_salt = {0x7f, 0xf5, 0x79, 0xe5, 0xac, 0xd0, 0x72,
+                      0x91, 0x55, 0x80, 0x30, 0x4c, 0x43, 0xa2,
+                      0x36, 0x7c, 0x60, 0x48, 0x83, 0x10}
+    } else if (version == T051) {
+      initial_salt = {0x7a, 0x4e, 0xde, 0xf4, 0xe7, 0xcc, 0xee,
+                      0x5f, 0xa4, 0x50, 0x6c, 0x19, 0x12, 0x4f,
+                      0xc8, 0xcc, 0xda, 0x6e, 0x03, 0x3d}
+    } else if (version == 0xff00001b) {
+      initial_salt = {0xc3, 0xee, 0xf7, 0x12, 0xc7, 0x2e, 0xbb,
+                      0x5a, 0x11, 0xa7, 0xd2, 0x43, 0x2b, 0xb4,
+                      0x63, 0x65, 0xbe, 0xf9, 0xf5, 0x02}
+    } else if (version == 0xff00001d) {
+      initial_salt = {0xaf, 0xbf, 0xec, 0x28, 0x99, 0x93, 0xd2,
+                      0x4c, 0x9e, 0x97, 0x86, 0xf1, 0x9c, 0x61,
+                      0x11, 0xe0, 0x43, 0x90, 0xa8, 0x99}
+    }
+~~~
+
+### Extracting the CRYPTO frame for different versions
+
+~~~
+  counter = 0
+  while (payload[counter] == 0) {
+    counter += 1
+  }
+  first_nonzero_payload_byte = payload[counter]
+  fnz_payload_byte_bit3 = ((first_nonzero_payload_byte & 0x20) != 0)
+  if (version == Q043 || version == Q046) {
+    if ((first_nonzero_payload_byte & 0x9f) != 0) {
+      abort("Unexpected frame")
+    }
+    if (payload[counter+1] != 0x01) {
+      abort("Unexpected stream ID")
+    }
+    counter += 2
+    if (fnz_payload_byte_bit3) {
+      stream_data_length = payload[counter:counter+2]
+      crypto_data = payload[counter+2:counter+2+stream_data_length]
+    } else {
+      crypto_data = payload[counter:]
+    }
+  } else if (version == Q050 || version == T050 || version == T051) {
+    if (first_nonzero_payload_byte != 0x08) {
+      abort("Unexpected frame")
+    }
+    if (payload[counter+1] != 0x00) {
+      abort("Unexpected crypto stream offset")
+    }
+    counter += 2
+    if ((payload[counter] & 0xc0) == 0) {
+      crypto_data_length = payload[counter]
+      counter += 1
+    } else {
+      crypto_data_length = payload[counter:counter+2]
+      counter += 2
+    }
+    crypto_data = payload[counter:counter+crypto_data_length]
+  } else {  // All other versions
+    if (first_nonzero_payload_byte != 0x06) {
+      abort("Unexpected frame")
+    }
+    if (payload[counter+1] != 0x00) {
+      abort("Unexpected crypto stream offset")
+    }
+    counter += 2
+    if ((payload[counter] & 0xc0) == 0) {
+      crypto_data_length = payload[counter]
+      counter += 1
+    } else {
+      crypto_data_length = payload[counter:counter+2]
+      counter += 2
+    }
+    crypto_data = payload[counter:counter+crypto_data_length]
+  }
+  
+  // Extracting the Client Hello from the Crypto Data
+    if (version == Q043 || version == Q046 || version == Q050) {
+    if (crypto_data[0:4] != "CHLO") {
+      abort("Unexpected handshake message")
+    }
+    ParseQuicCrypto(crypto_data)
+  } else {
+    ParseTLS(crypto_data)
+  }
+~~~

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -939,7 +939,8 @@ Google QUIC and IETF QUIC. These mechanisms will become
 irrelevant when IETF QUIC is fully deployed and Google QUIC is deprecated.
 
 Note that other than this appendix, nothing in this document applies to
-Google QUIC.
+Google QUIC. And the purpose of this appendix is merely to distinguish IETF QUIC 
+from any versions of Google QUIC.
 
 Conceptually, a Google QUIC version is an opaque 32bit field. When we refer to a
 version with four printable characters, we use its ASCII representation:


### PR DESCRIPTION
This PR adds a new section on extracting the SNI. I also copied (most of) the pseudo code from Davids document into the appendix. We need to decide if we want to keep this and if so, potentially add some more explanation there.

Also we could further strengthen the point out that both the 5-tuple and conn ID can change (as in David's doc). There is already text directly following the new SNI section on "flow association". If we want stronger text there, maybe we can capture that in a separate issue though.