### PR TITLE
reverse order of "no critical interface", fix #138

### DIFF
--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -302,12 +302,10 @@ direction without a peer-generated FIN, much like in TCP. However, an endpoint
 can abruptly close either the ingress or egress direction; these actions are
 fully independent of each other.
 
+QUIC does not provide an interface for exceptional handling of any stream.
 If a stream that is critical for an application is closed, the application can
-generate respective error messages on the application layer to inform the
-other end and/or the higher layer, and eventually indicate QUIC to reset
-the connection. QUIC, however, does not need to know which streams are
-critical, and does not provide an interface for exceptional handling of
-any stream.
+generate error messages on the application layer to inform the other end and/or
+the higher layer, which can eventually indicate QUIC to reset the connection. 
 
 Mapping of application data to streams is application-specific and described for
 HTTP/3 in {{QUIC-HTTP}}. In general, data that can be processed independently,

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -305,7 +305,7 @@ fully independent of each other.
 QUIC does not provide an interface for exceptional handling of any stream.
 If a stream that is critical for an application is closed, the application can
 generate error messages on the application layer to inform the other end and/or
-the higher layer, which can eventually indicate QUIC to reset the connection.
+the higher layer, which can eventually reset the QUIC connection.
 
 Mapping of application data to streams is application-specific and described for
 HTTP/3 in {{QUIC-HTTP}}. In general, data that can be processed independently,

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -305,7 +305,7 @@ fully independent of each other.
 QUIC does not provide an interface for exceptional handling of any stream.
 If a stream that is critical for an application is closed, the application can
 generate error messages on the application layer to inform the other end and/or
-the higher layer, which can eventually indicate QUIC to reset the connection. 
+the higher layer, which can eventually indicate QUIC to reset the connection.
 
 Mapping of application data to streams is application-specific and described for
 HTTP/3 in {{QUIC-HTTP}}. In general, data that can be processed independently,


### PR DESCRIPTION
after discussion with @mirjak, we probably do want to keep the information that "all streams are equal" here. 
Reverse the order of the sentences here to not bury the lede.