### PR TITLE
Reword TFO/0-rtt sentence.

### DIFF
--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -147,10 +147,11 @@ fallback to TLS over TCP, the most obvious difference is that TCP does not
 provide stream multiplexing and therefore stream multiplexing would need to be
 implemented in the application layer if needed. Further, TCP implementations
 and network paths often do not support the Fast Open option {{?RFC7413}}, which
-is required to to achieve true 0-RTT session resumption. Note that there is
+enables sending of payload data together with the first control packet of a new
+connection as also provided by 0-RTT session resumption in QUIC. Note that there is
 some evidence of middleboxes blocking SYN data even if TFO was successfully
 negotiated (see {{PaaschNanog}}). And even if Fast Open successfully operates
-end-to-end, it is limited to a single packet of payload, unlike QUIC 0-RTT.
+end-to-end, it is limited to a single packet of TLS handshake and application data, unlike QUIC 0-RTT.
 
 Moreover, while encryption (in this case TLS) is inseparably integrated with
 QUIC, TLS negotiation over TCP can be blocked. If TLS over TCP cannot be

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -151,7 +151,8 @@ enables sending of payload data together with the first control packet of a new
 connection as also provided by 0-RTT session resumption in QUIC. Note that there is
 some evidence of middleboxes blocking SYN data even if TFO was successfully
 negotiated (see {{PaaschNanog}}). And even if Fast Open successfully operates
-end-to-end, it is limited to a single packet of TLS handshake and application data, unlike QUIC 0-RTT.
+end-to-end, it is limited to a single packet of TLS handshake and application
+data, unlike QUIC 0-RTT.
 
 Moreover, while encryption (in this case TLS) is inseparably integrated with
 QUIC, TLS negotiation over TCP can be blocked. If TLS over TCP cannot be

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -146,11 +146,11 @@ absence of features provided by QUIC not present in the fallback protocol. For
 fallback to TLS over TCP, the most obvious difference is that TCP does not
 provide stream multiplexing and therefore stream multiplexing would need to be
 implemented in the application layer if needed. Further, TCP implementations
-and network paths often do not support the Fast Open option, which is analogous
-to 0-RTT session resumption. Note that there is some evidence of middleboxes
-blocking SYN data even if TFO was successfully negotiated (see {{PaaschNanog}}).
-And even if Fast Open successfully operates end-to-end, it is limited to a
-single packet of payload, unlike QUIC 0-RTT.
+and network paths often do not support the Fast Open option {{?RFC7413}}, which
+is required to to achieve true 0-RTT session resumption. Note that there is
+some evidence of middleboxes blocking SYN data even if TFO was successfully
+negotiated (see {{PaaschNanog}}). And even if Fast Open successfully operates
+end-to-end, it is limited to a single packet of payload, unlike QUIC 0-RTT.
 
 Moreover, while encryption (in this case TLS) is inseparably integrated with
 QUIC, TLS negotiation over TCP can be blocked. If TLS over TCP cannot be

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -148,11 +148,11 @@ provide stream multiplexing and therefore stream multiplexing would need to be
 implemented in the application layer if needed. Further, TCP implementations
 and network paths often do not support the Fast Open option {{?RFC7413}}, which
 enables sending of payload data together with the first control packet of a new
-connection as also provided by 0-RTT session resumption in QUIC. Note that there is
-some evidence of middleboxes blocking SYN data even if TFO was successfully
-negotiated (see {{PaaschNanog}}). And even if Fast Open successfully operates
-end-to-end, it is limited to a single packet of TLS handshake and application
-data, unlike QUIC 0-RTT.
+connection as also provided by 0-RTT session resumption in QUIC. Note that
+there is some evidence of middleboxes blocking SYN data even if TFO was
+successfully negotiated (see {{PaaschNanog}}). And even if Fast Open
+successfully operates end-to-end, it is limited to a single packet of TLS
+handshake and application data, unlike QUIC 0-RTT.
 
 Moreover, while encryption (in this case TLS) is inseparably integrated with
 QUIC, TLS negotiation over TCP can be blocked. If TLS over TCP cannot be


### PR DESCRIPTION
I don't think this sentence was accurate. TFO isn't analogous to 0-RTT session resumption, but it's needed to achieve the same application effect.