### PR TITLE
Split Connection Closure discussion into two parts

### DIFF
--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -496,9 +496,9 @@ Applications that use QUIC can define their own error detection and signaling
 (see, for example, {{Section 8 of QUIC-HTTP}}). Application errors can affect an
 entire connection or a single stream.
 
-QUIC defines an error code space that is used for error handling at the transport layer. QUIC
-encourages endpoints to use the most specific code, although any applicable code
-is permitted, including generic ones.
+QUIC defines an error code space that is used for error handling at the
+transport layer. QUIC encourages endpoints to use the most specific code,
+although any applicable code is permitted, including generic ones.
 
 Applications using QUIC define an error
 code space that is independent from QUIC or other applications (see, for

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -457,14 +457,14 @@ being terminated in some protocols.
 # Stream Limit Commitments
 
 QUIC endpoints are responsible for communicating the cumulative limit of streams
-they would allow to be opened by their peer. Initial limits are advertised
-using the initial_max_streams_bidi and initial_max_streams_uni transport
-parameters. As streams are opened and closed they are consumed and the cumulative
-total is incremented. Limits can be increased using the MAX_STREAMS frame but
-there is no mechanism to reduce limits. Once stream limits are reached, no more
-streams can be opened, which prevents applications using QUIC from making further
-progress. At this stage connections can be terminated via idle timeout or explicit
-close; see {{sec-termination}}).
+they would allow to be opened by their peer. Initial limits are advertised using
+the initial_max_streams_bidi and initial_max_streams_uni transport parameters.
+As streams are opened and closed they are consumed and the cumulative total is
+incremented. Limits can be increased using the MAX_STREAMS frame but there is no
+mechanism to reduce limits. Once stream limits are reached, no more streams can
+be opened, which prevents applications using QUIC from making further progress.
+At this stage connections can be terminated via idle timeout or explicit close;
+see {{sec-termination}}).
 
 An application that uses QUIC might communicate a cumulative stream limit but
 require the connection to be closed before the limit is reached. For example,

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -647,8 +647,8 @@ timeout values may free-up resources more quickly.
 
 Application data exchanged on streams or in datagrams defers the QUIC idle
 timeout. Applications that provide their own keep-alive mechanisms will
-therefore keep a QUIC connection alive. Applications that don't provide their
-own keep-alive might be able to use transport-layer mechanisms (see {{Section
+therefore keep a QUIC connection alive. Applications that do not provide their
+own keep-alive can use transport-layer mechanisms (see {{Section
 10.1.2 of QUIC}}, and {{resumption-v-keepalive}}). However, QUIC implementation
 interfaces for controlling such transport behavior can vary, affecting the
 robustness of such approaches.

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -465,9 +465,9 @@ streams, abrupt closure of actively used streams may be undesireable or
 detrimental. In contrast, waiting for an endpoint to exhaust the advertised
 limit may not suit application or operational needs. Applications using QUIC can
 use conservative stream limits and run to completion before enacting an
-immediate close. Alternatively, a graceful close mechanism can be used to
-communicate the intention to explicitly close the connection at some future
-point.
+immediate close. Alternatively, an application-layer graceful close mechanism
+can be used to communicate the intention to explicitly close the connection at
+some future point.
 
 # Packetization and Latency
 

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -461,29 +461,32 @@ they would allow to be opened by their peer. Initial limits are advertised
 using the initial_max_streams_bidi and initial_max_streams_uni transport
 parameters. As streams are opened and closed they are consumed and the cumulative
 total is incremented. Limits can be increased using the MAX_STREAMS frame but
-there is no mechanism to reduce limits. 
+there is no mechanism to reduce limits. Once stream limits are reached, no more
+streams can be opened, which prevents applications using QUIC from making further
+progress. At this stage connections can be terminated via idle timeout or explicit
+close; see {{sec-termination}}).
 
-An application that uses QUIC might communicate a cumulative stream limit
-but require the connection to be closed before the limit is reached. For example,
+An application that uses QUIC might communicate a cumulative stream limit but
+require the connection to be closed before the limit is reached. For example,
 stopping the server to perform scheduled maintenance. Immediate connection close
-(see {{connection-termination}}) causes abrupt closure of actively used streams.
-Depending on how an application uses QUIC streams, this could be undesireable
-or detrimental to behaviour or performance. An alternative to immediate close
-is to wait for a peer to consume all of the advertised stream limit. However, the
-period of time it takes to do so is dependent on the client and an unpredictable
-closing period might not fit application or operational needs. Applications using
-QUIC can be conservative with open stream limits in order to reduce the commitment
-and indeterminism. However, being overly conservative with stream limits affects
-stream concurrency. Balancing these aspects can be specific to applications and
-their deployments. Instead of relying on stream limits to avoid abrupt closure,
-an application-layer graceful close mechanism can be used to communicate the
-intention to explicitly close the connection at some future point. HTTP/3 provides
-such a mechanism using the GOWAWAY frame. In HTTP/3,
-when the GOAWAY frame is received by a client, it
+causes abrupt closure of actively used streams. Depending on how an application
+uses QUIC streams, this could be undesirable or detrimental to behavior or
+performance. A more graceful closure technique is to stop sending increases to
+stream limits and allow the connection to naturally terminate once remaining
+streams are consumed. However, the period of time it takes to do so is dependent
+on the client and an unpredictable closing period might not fit application or
+operational needs. Applications using QUIC can be conservative with open stream
+limits in order to reduce the commitment and indeterminism. However, being
+overly conservative with stream limits affects stream concurrency. Balancing
+these aspects can be specific to applications and their deployments. Instead of
+relying on stream limits to avoid abrupt closure, an application-layer graceful
+close mechanism can be used to communicate the intention to explicitly close the
+connection at some future point. HTTP/3 provides such a mechanism using the
+GOWAWAY frame. In HTTP/3, when the GOAWAY frame is received by a client, it
 stops opening new streams even if the cumulative stream limit would allow.
 Instead the client would create a new connection on which to open further
-streams.  Once all streams are closed on the old connection, it can be terminated
-safely be a connection close or after expiration of the idle time out
+streams.  Once all streams are closed on the old connection, it can be
+terminated safely by a connection close or after expiration of the idle time out
 (see also {{sec-termination}}).
 
 # Packetization and Latency

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -478,10 +478,13 @@ stream concurrency. Balancing these aspects can be specific to applications and
 their deployments. Instead of relying on stream limits to avoid abrupt closure,
 an application-layer graceful close mechanism can be used to communicate the
 intention to explicitly close the connection at some future point. HTTP/3 provides
-such a mechanism using the GOWAWAY frame. When received by a client, it
-stops opening new streams even if the cumulative stream limit would allow. The 
-client can create a new connection on which to open further streams, once all
-streams close on the old connection it can be closed safely.
+such a mechanism using the GOWAWAY frame. In HTTP/3,
+when the GOAWAY frame is received by a client, it
+stops opening new streams even if the cumulative stream limit would allow.
+Instead the client would create a new connection on which to open further
+streams.  Once all streams are closed on the old connection, it can be terminated
+safely be a connection close or after expiration of the idle time out
+(see also {{sec-termination}}).
 
 # Packetization and Latency
 
@@ -621,7 +624,7 @@ to the server instance. The server can provide an IPv4 and an IPv6 address in a
 transport parameter during the TLS handshake and the client can select between
 the two if both are provided. See also {{Section 9.6 of QUIC}}.
 
-# Connection Termination
+# Connection Termination {#sec-termination}
 
 QUIC connections are terminated in one of three ways: implicit idle timeout,
 explicit immediate close, or explicit stateless reset.

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -503,7 +503,7 @@ is permitted, including generic ones.
 Applications using QUIC define an error
 code space that is independent from QUIC or other applications (see, for
 example, {{Section 8.1 of QUIC-HTTP}}). The values in an application error code
-space are reused across connection-level and stream-level errors.
+space can be reused across connection-level and stream-level errors.
 
 Connection errors lead to connection termination. They are signaled using a
 CONNECTION_CLOSE frame, which contains an error code and a reason field that can

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -645,14 +645,13 @@ connection. An application may adjust the maximum idle timeout for new
 connections based on the number of open or expected connections, since shorter
 timeout values may free-up resources more quickly.
 
-As long as application data is exchanged, the idle timeout does not expire. If
-an application has no data to send but desires to keep the connection open for
-longer than the timeout period, it can send keep-alive messages. A QUIC
-implementation may provide an option to defer the time-out by sending keep-alive
-messages at the transport layer to avoid unnecessary load, as specified in
-{{Section 10.1.2 of QUIC}}. Alternatively, applications using QUIC could define
-their own mechanism, such as an application-layer ping, that achieves a similar
-result. See {{resumption-v-keepalive}} for further guidance on keep-alives.
+Application data exchanged on streams or in datagrams defers the QUIC idle
+timeout. Applications that provide their own keep-alive mechanisms will
+therefore keep a QUIC connection alive. Applications that don't provide their
+own keep-alive might be able to use transport-layer mechanisms (see {{Section
+10.1.2 of QUIC}}, and {{resumption-v-keepalive}}). However, QUIC implementation
+interfaces for controlling such transport behavior can vary, affecting the
+robustness of such approaches.
 
 An immediate close is signaled by a CONNECTION_CLOSE frame (see
 {{error-handling}}). Immediate close causes all streams to become immediately

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -456,18 +456,32 @@ being terminated in some protocols.
 
 # Stream Limit Commitments
 
-QUIC endpoints can manage the cumulative maximum number of streams they would
-allow to be opened using the MAX_STREAMS frame, but there is no mechanism to
-reduce the value. An application that uses QUIC might commit to a number of
-openable streams but require the connection to be closed (for example, a
-scheduled maintenance period). Depending on how an application uses QUIC
-streams, abrupt closure of actively used streams may be undesireable or
-detrimental. In contrast, waiting for an endpoint to exhaust the advertised
-limit may not suit application or operational needs. Applications using QUIC can
-use conservative stream limits and run to completion before enacting an
-immediate close. Alternatively, an application-layer graceful close mechanism
-can be used to communicate the intention to explicitly close the connection at
-some future point.
+QUIC endpoints are responsible for communicating the cumulative limit of streams
+they would allow to be opened by their peer. Initial limits are advertised
+using the initial_max_streams_bidi and initial_max_streams_uni transport
+parameters. As streams are opened and closed they are consumed and the cumulative
+total is incremented. Limits can be increased using the MAX_STREAMS frame but
+there is no mechanism to reduce limits. 
+
+An application that uses QUIC might communicate a cumulative stream limit
+but require the connection to be closed before the limit is reached. For example,
+stopping the server to perform scheduled maintenance. Immediate connection close
+(see {{connection-termination}}) causes abrupt closure of actively used streams.
+Depending on how an application uses QUIC streams, this could be undesireable
+or detrimental to behaviour or performance. An alternative to immediate close
+is to wait for a peer to consume all of the advertised stream limit. However, the
+period of time it takes to do so is dependent on the client and an unpredictable
+closing period might not fit application or operational needs. Applications using
+QUIC can be conservative with open stream limits in order to reduce the commitment
+and indeterminism. However, being overly conservative with stream limits affects
+stream concurrency. Balancing these aspects can be specific to applications and
+their deployments. Instead of relying on stream limits to avoid abrupt closure,
+an application-layer graceful close mechanism can be used to communicate the
+intention to explicitly close the connection at some future point. HTTP/3 provides
+such a mechanism using the GOWAWAY frame. When received by a client, it
+stops opening new streams even if the cumulative stream limit would allow. The 
+client can create a new connection on which to open further streams, once all
+streams close on the old connection it can be closed safely.
 
 # Packetization and Latency
 

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -468,7 +468,7 @@ close; see {{sec-termination}}).
 
 An application that uses QUIC might communicate a cumulative stream limit but
 require the connection to be closed before the limit is reached. For example,
-stopping the server to perform scheduled maintenance. Immediate connection close
+to stop the server to perform scheduled maintenance. Immediate connection close
 causes abrupt closure of actively used streams. Depending on how an application
 uses QUIC streams, this could be undesirable or detrimental to behavior or
 performance. A more graceful closure technique is to stop sending increases to

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -498,7 +498,9 @@ entire connection or a single stream.
 
 QUIC defines an error code space that is used for error handling at the transport layer. QUIC
 encourages endpoints to use the most specific code, although any applicable code
-is permitted including generic ones. Applications using QUIC can define an error
+is permitted, including generic ones.
+
+Applications using QUIC define an error
 code space that is independent from QUIC or other applications (see, for
 example, {{Section 8.1 of QUIC-HTTP}}). The values in an application error code
 space are reused across connection-level and stream-level errors.

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -492,7 +492,7 @@ interface that allows an application layer to specify how to apply padding.
 QUIC recommends that endpoints signal any detected errors to
 the peer. Errors can occur at the transport level and the application level.
 Transport errors, such as a protocol violation, affect the entire connection.
-Applications that use QUIC can define their own error detection and signalling
+Applications that use QUIC can define their own error detection and signaling
 (see, for example, {{Section 8 of QUIC-HTTP}}). Application errors can affect an
 entire connection or a single stream.
 
@@ -615,7 +615,7 @@ messages at the transport layer to avoid unnecessary load, as specified in
 their own mechanism, such as an application-layer ping, that achieves a similar
 result. See {{resumption-v-keepalive}} for further guidance on keep-alives.
 
-An immediate close is signalled by a CONNECTION_CLOSE frame (see
+An immediate close is signaled by a CONNECTION_CLOSE frame (see
 {{error-handling}}). Immediate close causes all streams to become immediately
 closed. QUIC endpoints can manage the cumulative maximum number of streams they
 would allow to be opened using the MAX_STREAMS frame, but there is no mechanism

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -489,15 +489,15 @@ interface that allows an application layer to specify how to apply padding.
 
 # Error Handling
 
-QUIC recommends that endpoints that detect errors should signal the occurance to
+QUIC recommends that endpoints signal any detected errors to
 the peer. Errors can occur at the transport level and the application level.
 Transport errors, such as a protocol violation, affect the entire connection.
 Applications that use QUIC can define their own error detection and signalling
 (see, for example, {{Section 8 of QUIC-HTTP}}). Application errors can affect an
 entire connection or a single stream.
 
-QUIC defines an error code space that is used for error handling. QUIC
-encourages endpoints to use the most-specific code, although any applicable code
+QUIC defines an error code space that is used for error handling at the transport layer. QUIC
+encourages endpoints to use the most specific code, although any applicable code
 is permitted including generic ones. Applications using QUIC can define an error
 code space that is independent from QUIC or other applications (see, for
 example, {{Section 8.1 of QUIC-HTTP}}). The values in an application error code
@@ -505,8 +505,8 @@ space are reused across connection-level and stream-level errors.
 
 Connection errors lead to connection termination. They are signaled using a
 CONNECTION_CLOSE frame, which contains an error code and a reason field that can
-be zero length. CONNECTION_CLOSE has two frame type values: 0x1c is used for
-QUIC-level errors, 0x1d is used for application-level errors.
+be zero length. Different types of CONNECTION_CLOSE frame are used to
+signal transport and application errors.
 
 Stream errors lead to stream termination. The are signaled using STOP_SENDING or
 RESET_STREAM frames, which contain only an error code.
@@ -602,7 +602,7 @@ silently closed. An application therefore should be able to configure its own
 maximum value, as well as have access to the computed minimum value for this
 connection. An application may adjust the maximum idle timeout for new
 connections based on the number of open or expected connections, since shorter
-timeout values may free-up memory more quickly.
+timeout values may free-up resources more quickly.
 
 As long as application data is exchanged, the idle timeout does not expire. If
 an application has no data to send but desires to keep the connection open for
@@ -616,18 +616,18 @@ result. See {{resumption-v-keepalive}} for further guidance on keep-alives.
 An immediate close is signalled by a CONNECTION_CLOSE frame (see
 {{error-handling}}). Immediate close causes all streams to become immediately
 closed. QUIC endpoints can manage the cumulative maximum number of streams they
-would allow to be opened using the MAX_STREAMS frames but there is no mechanism
+would allow to be opened using the MAX_STREAMS frame, but there is no mechanism
 to reduce the value. An application that uses QUIC might commit to a number of
 openable streams but require the connection to be closed (for example, a
 scheduled maintenance period). Depending on how an application uses QUIC streams
-(see {{use-of-streams}}), abrupt closure of actively-used streams may be
+(see {{use-of-streams}}), abrupt closure of actively used streams may be
 undesireable or detrimental. In contrast, waiting for an endpoint to exhaust the
 advertised limit may not suit application or operational needs. Applications
 using QUIC can use conservative stream limits and run to completion before
-enacting and immediate close. Alternatively, a graceful close mechanim can be
-used to commicate the intention to explicitly close the connection at some
+enacting an immediate close. Alternatively, a graceful close mechanism can be
+used to communicate the intention to explicitly close the connection at some
 future point. QUIC does not provide any mechanism for graceful connection
-termination, applications using QUIC can define their own graceful termination
+termination; applications using QUIC can define their own graceful termination
 process (see, for example, {{Section 5.2 of QUIC-HTTP}}).
 
 A stateless reset is an option of last resort for an endpoint that does not have

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -633,8 +633,7 @@ termination; applications using QUIC can define their own graceful termination
 process (see, for example, {{Section 5.2 of QUIC-HTTP}}).
 
 A stateless reset is an option of last resort for an endpoint that does not have
-access to connection state. It is not expected that application using QUIC need
-information or knowledge that a stateless reset was triggered.
+access to connection state. Receiving a stateless reset is an indication of an unrecoverable error distinct from connection errors in that there is no application-layer information provided.
 
 
 # Information Exposure and the Connection ID {#connid}

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -487,6 +487,30 @@ Padding can also be used by an application to reduce leakage of
 information about the data that is sent. A QUIC implementation can expose an
 interface that allows an application layer to specify how to apply padding.
 
+# Error Handling
+
+QUIC recommends that endpoints that detect errors should signal the occurance to
+the peer. Errors can occur at the transport level and the application level.
+Transport errors, such as a protocol violation, affect the entire connection.
+Applications that use QUIC can define their own error detection and signalling
+(see, for example, {{Section 8 of QUIC-HTTP}}). Application errors can affect an
+entire connection or a single stream.
+
+QUIC defines an error code space that is used for error handling. QUIC
+encourages endpoints to use the most-specific code, although any applicable code
+is permitted including generic ones. Applications using QUIC can define an error
+code space that is independent from QUIC or other applications (see, for
+example, {{Section 8.1 of QUIC-HTTP}}). The values in an application error code
+space are reused across connection-level and stream-level errors.
+
+Connection errors lead to connection termination. They are signaled using a
+CONNECTION_CLOSE frame, which contains an error code and a reason field that can
+be zero length. CONNECTION_CLOSE has two frame type values: 0x1c is used for
+QUIC-level errors, 0x1d is used for application-level errors.
+
+Stream errors lead to stream termination. The are signaled using STOP_SENDING or
+RESET_STREAM frames, which contain only an error code.
+
 # ACK-only packets on constrained links
 
 The cost of sending acknowledgments - in processing cost or link

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -633,7 +633,9 @@ termination; applications using QUIC can define their own graceful termination
 process (see, for example, {{Section 5.2 of QUIC-HTTP}}).
 
 A stateless reset is an option of last resort for an endpoint that does not have
-access to connection state. Receiving a stateless reset is an indication of an unrecoverable error distinct from connection errors in that there is no application-layer information provided.
+access to connection state. Receiving a stateless reset is an indication of an
+unrecoverable error distinct from connection errors in that there is no
+application-layer information provided.
 
 
 # Information Exposure and the Connection ID {#connid}

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -454,6 +454,21 @@ Some deadlocking scenarios might be resolved by cancelling affected streams with
 STOP_SENDING or RESET_STREAM.  Cancelling some streams results in the connection
 being terminated in some protocols.
 
+# Stream Limit Commitments
+
+QUIC endpoints can manage the cumulative maximum number of streams they would
+allow to be opened using the MAX_STREAMS frame, but there is no mechanism to
+reduce the value. An application that uses QUIC might commit to a number of
+openable streams but require the connection to be closed (for example, a
+scheduled maintenance period). Depending on how an application uses QUIC
+streams, abrupt closure of actively used streams may be undesireable or
+detrimental. In contrast, waiting for an endpoint to exhaust the advertised
+limit may not suit application or operational needs. Applications using QUIC can
+use conservative stream limits and run to completion before enacting an
+immediate close. Alternatively, a graceful close mechanism can be used to
+communicate the intention to explicitly close the connection at some future
+point.
+
 # Packetization and Latency
 
 QUIC exposes an interface that provides multiple streams to the application;
@@ -597,6 +612,10 @@ the two if both are provided. See also {{Section 9.6 of QUIC}}.
 QUIC connections are terminated in one of three ways: implicit idle timeout,
 explicit immediate close, or explicit stateless reset.
 
+QUIC does not provide any mechanism for graceful connection termination;
+applications using QUIC can define their own graceful termination process (see,
+for example, {{Section 5.2 of QUIC-HTTP}}).
+
 QUIC idle timeout is enabled via transport parameters. Client and server
 announce a timeout period and the effective value for the connection is the
 minimum of the two values. After the timeout period elapses, the connection is
@@ -617,20 +636,7 @@ result. See {{resumption-v-keepalive}} for further guidance on keep-alives.
 
 An immediate close is signaled by a CONNECTION_CLOSE frame (see
 {{error-handling}}). Immediate close causes all streams to become immediately
-closed. QUIC endpoints can manage the cumulative maximum number of streams they
-would allow to be opened using the MAX_STREAMS frame, but there is no mechanism
-to reduce the value. An application that uses QUIC might commit to a number of
-openable streams but require the connection to be closed (for example, a
-scheduled maintenance period). Depending on how an application uses QUIC streams
-(see {{use-of-streams}}), abrupt closure of actively used streams may be
-undesireable or detrimental. In contrast, waiting for an endpoint to exhaust the
-advertised limit may not suit application or operational needs. Applications
-using QUIC can use conservative stream limits and run to completion before
-enacting an immediate close. Alternatively, a graceful close mechanism can be
-used to communicate the intention to explicitly close the connection at some
-future point. QUIC does not provide any mechanism for graceful connection
-termination; applications using QUIC can define their own graceful termination
-process (see, for example, {{Section 5.2 of QUIC-HTTP}}).
+closed, which may affect applications; see {{stream-limit-commitments}}.
 
 A stateless reset is an option of last resort for an endpoint that does not have
 access to connection state. Receiving a stateless reset is an indication of an


### PR DESCRIPTION
Fixes #297 and #175.

This ended up much larger than I anticiated but I found the old Connection Closure text quite hard to modify in a way that let me frame the graceful close additions. 

I think this is a net positive structural move, even if we might need to bash the section ordering and contained text.