### PR TITLE
Try to make flow control consuming and processing crisper

### DIFF
--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -425,7 +425,8 @@ transport-layer and application-layer receive buffers. Consuming data does not
 always imply it is immediately processed. However, a common flow control
 implementation technique is to extend credit to the sender, by emitting MAX_DATA
 and/or MAX_STREAM_DATA frames, as data is consumed. Delivery of these frames
-is affected by uplink latency. If credit is not extended in a timely manner, the
+is affected by the latency of the back channel from the receiver to the data sender.
+If credit is not extended in a timely manner, the
 sending application can be blocked, effectively throttling the downlink.
 
 Large application messages can produce deadlocking if the recipient does not

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -418,9 +418,9 @@ whether they become a problem depends on how implementations consume data and
 provide flow control credit.  Understanding what causes deadlocking might help
 implementations avoid deadlocks.
 
+Timely updates of transport flow control credit can improve performance.
 Applications that use QUIC often have a data consumer that reads data from
-transport buffers. Timely updates of transport flow control credit can improve
-performance. A common flow control implementation technique is for a QUIC
+transport buffers. A common flow control implementation technique is for a QUIC
 receiver to extend credit to the sender as the data consumer reads data.  Some
 implementations might have independent transport-layer and application-layer
 receive buffers. Consuming data does not always imply it is immediately

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -418,13 +418,15 @@ whether they become a problem depends on how implementations consume data and
 provide flow control credit.  Understanding what causes deadlocking might help
 implementations avoid deadlocks.
 
-Timely updates of transport flow control credit can improve performance.
-Applications that use QUIC often have a data consumer that reads data from
-transport buffers. A common flow control implementation technique is for a QUIC
-receiver to extend credit to the sender as the data consumer reads data.  Some
-implementations might have independent transport-layer and application-layer
-receive buffers. Consuming data does not always imply it is immediately
-processed. However, when data is consumed,
+The size and rate of transport flow control credit updates can affect
+performance. Applications that use QUIC often have a data consumer that reads
+data from transport buffers. Some implementations might have independent
+transport-layer and application-layer receive buffers. Consuming data does not
+always imply it is immediately processed. However, a common flow control
+implementation technique is to extend credit to the sender, by emitting MAX_DATA
+and/or MAX_STREAM_DATA frames, as data is consumed. Delivery of these frames
+is affected by uplink latency. If credit is not extended in a timely manner, the
+sending application can be blocked, effectively throttling the downlink.
 
 Large application messages can produce deadlocking if the recipient does not
 read data from the transport incrementally. If the message is larger than the

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -425,8 +425,8 @@ transport-layer and application-layer receive buffers. Consuming data does not
 always imply it is immediately processed. However, a common flow control
 implementation technique is to extend credit to the sender, by emitting MAX_DATA
 and/or MAX_STREAM_DATA frames, as data is consumed. Delivery of these frames
-is affected by the latency of the back channel from the receiver to the data sender.
-If credit is not extended in a timely manner, the
+is affected by the latency of the back channel from the receiver to the data
+sender. If credit is not extended in a timely manner, the
 sending application can be blocked, effectively throttling the sender.
 
 Large application messages can produce deadlocking if the recipient does not

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -427,7 +427,7 @@ implementation technique is to extend credit to the sender, by emitting MAX_DATA
 and/or MAX_STREAM_DATA frames, as data is consumed. Delivery of these frames
 is affected by the latency of the back channel from the receiver to the data sender.
 If credit is not extended in a timely manner, the
-sending application can be blocked, effectively throttling the downlink.
+sending application can be blocked, effectively throttling the sender.
 
 Large application messages can produce deadlocking if the recipient does not
 read data from the transport incrementally. If the message is larger than the


### PR DESCRIPTION
Fixes #193.

This mainly wiggles the existing text around and tries to fully qualify transport vs application to help explain the ways an implementation might do things, which is independent of how an application protocol might be designed (for example H3 doesn't require incremental processing but most people come to a realizatopm that it is the best way to do things).