### PR TITLE
Rewrite Stateful Treatment section

### DIFF
--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -846,13 +846,14 @@ client needs to expire before a re-establishment can happen (if at all), which
 would lead to unnecessary long delays in an otherwise working connection.
 	
 Furrther, not all endpoints use routing architectures where connections will
-survive a port or address change. So even when the client revives the connection,
-a NAT rebinding can cause a routing mismatch where a packet is not even delivered to
-the server that might support address migration. 
+survive a port or address change. So even when the client revives the
+connection, a NAT rebinding can cause a routing mismatch where a packet
+is not even delivered to the server that might support address migration.
 	
-For these reasons, the limits in {{?RFC4787}} are important to avoid black-holing
-of packets (and hence avoid interrupting the flow of data to the client), especially
-where devices are able to distinguish QUIC traffic from other UDP payloads.
+For these reasons, the limits in {{?RFC4787}} are important to avoid 
+black-holing of packets (and hence avoid interrupting the flow of data to the
+client), especially where devices are able to distinguish QUIC traffic from
+other UDP payloads.
 
 The QUIC header optionally contains a connection ID which can be used as
 additional entropy beyond the 5-tuple, if needed. The QUIC handshake needs

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -840,7 +840,7 @@ timer of at least two minutes for QUIC traffic.
 
 While QUIC has no clear network-visible end-of-connection signal and therefore
 does require timer-based state removal, the QUIC handshake indicates
-confirmation of both ends that a valid bidirectional transmission is on-going.
+confirmation by both ends of a valid bidirectional transmission.
 If state is removed too early, this could lead to black-holing of incoming
 packets after a short idle period. To detect this situation, a timer at the
 client needs to expire before a re-establishment can happen (if at all), which

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -683,6 +683,7 @@ to NAT rebinding or address migration. An observer keeping flow state
 can associate a connection ID, if present, with a given flow, and can associate
 a known flow with a new flow when when observing a packet sharing the same
 connection ID in the same direction between client and server and sharing one
+endpoint address (IP address and port) with the known flow.
 
 However, since the connection ID may change multiple times during the lifetime
 of a flow, and the negotiation of connection ID changes is encrypted, packets

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -850,7 +850,7 @@ survive a port or address change. So even when the client revives the
 connection, a NAT rebinding can cause a routing mismatch where a packet
 is not even delivered to the server that might support address migration.
 	
-For these reasons, the limits in {{?RFC4787}} are important to avoid 
+For these reasons, the limits in {{?RFC4787}} are important to avoid
 black-holing of packets (and hence avoid interrupting the flow of data to the
 client), especially where devices are able to distinguish QUIC traffic from
 other UDP payloads.

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -836,7 +836,6 @@ rebindings, which might look like a tempting feature to further reduce the UDP
 timeout and thereby minimize state, this is not recommended.  Instead it is
 recommended, even when lower timers are used for other UDP traffic, to use a
 timer of at least two minutes for QUIC traffic.
-	
 While QUIC has no clear network-visible end-of-connection signal and therefore
 does require timer-based state removal, the QUIC handshake indicates
 confirmation of both ends that a valid bidirectional transmission is on-going.
@@ -844,12 +843,10 @@ If state is removed too early, this could lead to black-holing of incoming
 packets after a short idle period. To detect this situation, a timer at the
 client needs to expire before a re-establishment can happen (if at all), which
 would lead to unnecessary long delays in an otherwise working connection.
-	
-Furrther, not all endpoints use routing architectures where connections will
-survive a port or address change. So even when the client revives the
+Furthermore, not all endpoints use routing architectures where connections
+will survive a port or address change. So even when the client revives the
 connection, a NAT rebinding can cause a routing mismatch where a packet
 is not even delivered to the server that might support address migration.
-	
 For these reasons, the limits in {{?RFC4787}} are important to avoid
 black-holing of packets (and hence avoid interrupting the flow of data to the
 client), especially where devices are able to distinguish QUIC traffic from

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -844,6 +844,7 @@ If state is removed too early, this could lead to black-holing of incoming
 packets after a short idle period. To detect this situation, a timer at the
 client needs to expire before a re-establishment can happen (if at all), which
 would lead to unnecessary long delays in an otherwise working connection.
+
 Furthermore, not all endpoints use routing architectures where connections
 will survive a port or address change. So even when the client revives the
 connection, a NAT rebinding can cause a routing mismatch where a packet

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -837,6 +837,7 @@ rebindings, which might look like a tempting feature to further reduce the UDP
 timeout and thereby minimize state, this is not recommended.  Instead it is
 recommended, even when lower timers are used for other UDP traffic, to use a
 timer of at least two minutes for QUIC traffic.
+
 While QUIC has no clear network-visible end-of-connection signal and therefore
 does require timer-based state removal, the QUIC handshake indicates
 confirmation of both ends that a valid bidirectional transmission is on-going.

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -832,11 +832,12 @@ to 60 seconds. In contrast, {{?RFC5382}} recommends a timeout of more than 2
 hours for TCP, given that TCP is a connection-oriented protocol with well-
 defined closure semantics.
 
-Even though QUIC has explicitly been designed tolerate NAT rebindings, decreasing the
-NAT timeout is not recommended, as it may negatively impact application performance
-or incentivize endpoints to send very frequent keep-alive packets.  Instead it is
-recommended, even when lower timers are used for other UDP traffic, to use a
-timer of at least two minutes for QUIC traffic.
+Even though QUIC has explicitly been designed tolerate NAT rebindings,
+decreasing the NAT timeout is not recommended, as it may negatively impact
+application performance or incentivize endpoints to send very frequent
+keep-alive packets. Instead it is recommended, even when lower timers are
+used for other UDP traffic, to use a timer of at least two minutes for QUIC
+traffic.
 
 While QUIC has no clear network-visible end-of-connection signal and therefore
 does require timer-based state removal, the QUIC handshake indicates

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -832,9 +832,9 @@ to 60 seconds. In contrast, {{?RFC5382}} recommends a timeout of more than 2
 hours for TCP, given that TCP is a connection-oriented protocol with well-
 defined closure semantics.
 
-Even though QUIC has explicitly been designed to improve robustness to NAT
-rebindings, which might look like a tempting feature to further reduce the UDP
-timeout and thereby minimize state, this is not recommended.  Instead it is
+Even though QUIC has explicitly been designed tolerate NAT rebindings, decreasing the
+NAT timeout is not recommended, as it may negatively impact application performance
+or incentivize endpoints to send very frequent keep-alive packets.  Instead it is
 recommended, even when lower timers are used for other UDP traffic, to use a
 timer of at least two minutes for QUIC traffic.
 


### PR DESCRIPTION
Fixes #183. Fixes #184. Fixes #204

This PR replaces #222 (while retaining the semantics of all of its changes); #222 no longer merges due to major changes to the NAT and Connection ID text.