### PR TITLE
Reference cleanup

### DIFF
--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -84,7 +84,6 @@ informative:
         ins: P. Sarolahti
       -
         ins: M. Kojo
-  I-D.nottingham-httpbis-retry:
   RFC5077:
   QUIC-HTTP: I-D.ietf-quic-http
   RFC8085:
@@ -266,7 +265,7 @@ periods may result in excessive unproductive traffic in some situations, and to
 unacceptable power usage for power-constrained (mobile) devices. Additionally,
 timeouts shorter than 30 seconds can make it harder to handle transient network
 interruptions, such as VM migration or coverage loss during mobilty.
-See {{?RFC8085}}, especially Section 3.5.
+See {{RFC8085}}, especially Section 3.5.
 
 Alternatively, the client (but not the server) can use session resumption
 instead of sending keepalive traffic. In this case, a client that wants to send
@@ -764,7 +763,7 @@ the old version is no longer accepted.
 {{?I-D.ietf-quic-datagram}} specifies a QUIC extension to enable sending
 and receiving unreliable datagrams over QUIC. Unlike operating directly over
 UDP, applications that use the QUIC datagram service do not need to implement
-their own congestion control, per {{?RFC8085}}, as QUIC datagrams are
+their own congestion control, per {{RFC8085}}, as QUIC datagrams are
 congestion controlled.
 
 QUIC datagrams are not flow-controlled, and as such data chunks may be dropped

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -761,7 +761,7 @@ the old version is no longer accepted.
 
 # Unreliable Datagram Service over QUIC
 
-{{?I-D.draft-ietf-quic-datagram}} specifies a QUIC extension to enable sending
+{{?I-D.ietf-quic-datagram}} specifies a QUIC extension to enable sending
 and receiving unreliable datagrams over QUIC. Unlike operating directly over
 UDP, applications that use the QUIC datagram service do not need to implement
 their own congestion control, per {{?RFC8085}}, as QUIC datagrams are

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -87,6 +87,7 @@ informative:
   I-D.nottingham-httpbis-retry:
   RFC5077:
   QUIC-HTTP: I-D.ietf-quic-http
+  RFC8085:
 
 
 --- abstract
@@ -218,8 +219,8 @@ period of at least 124 minutes, though there is not evidence of widespread
 implementation of this guideline in the literature. Short network timeout for
 UDP, however, is well-documented. According to a 2010 study
 ({{Hatonen10}}), UDP applications can assume that any NAT binding or other
-state entry can expire after just thirty seconds of inactivity.  Section 3.5
-of {{?RFC8085}} further discusses keep-alive intervals for UDP: it
+state entry can expire after just thirty seconds of inactivity.  {{Section 3.5
+of RFC8085}} further discusses keep-alive intervals for UDP: it
 requires a minimum value of 15 seconds, but recommends larger values, or
 omitting keep-alive entirely.
 
@@ -476,12 +477,11 @@ wait before bundle frames into a packet.
 
 Similarly, an application has usually no control about the length of a QUIC
 packet on the wire. QUIC provides the ability to add a PADDING frame to
-arbitrarily increase the size of packets. Padding is used by QUIC to ensure
-that the path is capable of transferring datagrams of at least a certain size,
-during the handshake (see Sections 8.1 and 14.1 of {{!QUIC}}) and for path
-validation after connection migration (see {{Section 8.2 of QUIC}}) as well
-as for Datagram Packetization Layer PMTU Discovery (DPLMTUD) (see Section 14.3
-of {{!QUIC}}).
+arbitrarily increase the size of packets. Padding is used by QUIC to ensure that
+the path is capable of transferring datagrams of at least a certain size, during
+the handshake (see {{Sections 8.1 and 14.1 of QUIC}}) and for path validation
+after connection migration (see {{Section 8.2 of QUIC}}) as well as for Datagram
+Packetization Layer PMTU Discovery (DPLMTUD) (see {{Section 14.3 of QUIC}}).
 
 Padding can also be used by an application to reduce leakage of
 information about the data that is sent. A QUIC implementation can expose an

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -53,6 +53,7 @@ informative:
     date: 2016-12-09
   RFC7605:
   QUIC-RECOVERY: I-D.ietf-quic-recovery
+  RFC4459:
 
 --- abstract
 
@@ -534,8 +535,8 @@ given flow is using QUIC based upon a UDP port number may therefore not hold;
 see also {{Section 5 of RFC7605}}.
 
 While the second-most-significant bit (0x40) of the first octet is set to 1 in
-most QUIC packets of the current version (see {{public-header}} and Section 17
-of {{QUIC-TRANSPORT}}), this method of recognizing QUIC traffic is not reliable.
+most QUIC packets of the current version (see {{public-header}} and {{Section 17
+of QUIC-TRANSPORT}}), this method of recognizing QUIC traffic is not reliable.
 First, it only provides one bit of information and is prone to collision with
 UDP-based protocols other than those considered in {{?RFC7983}}. Second, this
 feature of the wire image is not invariant {{QUIC-INVARIANTS}} and may change in
@@ -716,8 +717,8 @@ The round-trip time of QUIC flows can be inferred by observation once per flow,
 during the handshake, as in passive TCP measurement; this requires parsing of
 the QUIC packet header and recognition of the handshake, as illustrated in
 {{handshake}}. It can also be inferred during the flow's lifetime, if the
-endpoints use the spin bit facility described below and in Section 17.3.1 of
-{{QUIC-TRANSPORT}}.
+endpoints use the spin bit facility described below and in {{Section 17.3.1 of
+QUIC-TRANSPORT}}.
 
 ### Measuring Initial RTT
 
@@ -873,7 +874,7 @@ address-port mapping for flows based on connection ID might seem
 like a solution to this problem. However, hiding information about the
 change of the IP address or port conceals important and security-relevant
 information from QUIC endpoints and as such would facilitate amplification
-attacks (see section 9 of {{QUIC-TRANSPORT}}). An NAT function that hides
+attacks (see {{Section 9 of QUIC-TRANSPORT}}). A NAT function that hides
 peer address changes prevents the other end from
 detecting and mitigating attacks as the endpoint cannot verify connectivity
 to the new address using QUIC PATH_CHALLENGE and PATH_RESPONSE frames.
@@ -1008,7 +1009,7 @@ and memory costs, leading to a bottleneck that limits network capacity. In such
 networks this generates a desire to influence a majority of senders to use
 smaller packets, so that the limited reassembly capacity is not exceeded.
 
-For TCP, MSS clamping (Section 3.2 of {?RFC4459}}) is often used to change
+For TCP, MSS clamping ({{Section 3.2 of RFC4459}}) is often used to change
 the sender's maximum TCP segment size, but QUIC requires a different approach.
 {{Section 14 of QUIC-TRANSPORT}} advises senders to probe larger sizes using
 Datagram Packetization Layer PMTU Discovery ({{?DPLPMTUD=RFC8899}}) or Path

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -221,7 +221,7 @@ ID; see {{Section 17.2 of QUIC-TRANSPORT}}.
 
 Applications that have a mapping for TCP as well as QUIC are expected to
 use the same port number for both services. However, as for all other IETF
-transports {{?RFC7605}}, there is no guarantee that a specific application
+transports {{RFC7605}}, there is no guarantee that a specific application
 will use a given registered port, or that a given port carries traffic belonging
 to the respective registered service, especially when application layer
 information is encrypted. For example, {{QUIC-HTTP}} specifies


### PR DESCRIPTION
Some section refs weren't linked to the sections; some objects were defined multiple ways; one reference wasn't actually cited in the text.