### PR TITLE
Shorter text for failover text

### DIFF
--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -623,12 +623,11 @@ Use of a non-zero-length connection ID for the server is strongly recommended if
 any clients are behind a NAT or could be. A non-zero-length connection ID is
 also strongly recommended when migration is supported.
 
-Currently QUIC only supports failover cases. Only one "path" can be used at a
-time; and only when the new path is validated, all traffic can be switched over
-to that new path. Path validation means that the remote endpoint is required to
-validate the new path before use in order to avoid address spoofing attacks.
-Path validation takes at least one RTT and congestion control will also be reset
-after path migration. Therefore migration usually has a performance impact.
+Currently QUIC only supports the use of a single network path at a time, which
+enables failover use cases.  Path validation is required so that endpoints
+validate paths before use to avoid address spoofing attacks.  Path validation
+takes at least one RTT and congestion control will also be reset after path
+migration. Therefore migration usually has a performance impact.
 
 QUIC probing packets, which can be sent on multiple paths at once, are used
 to perform address validation as well as measure path characteristics as input


### PR DESCRIPTION
The original was factually incorrect as a new path can be used before validating it.