### PR TITLE
Deciding to use a new path

### DIFF
--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -630,12 +630,12 @@ validate the new path before use in order to avoid address spoofing attacks.
 Path validation takes at least one RTT and congestion control will also be reset
 after path migration. Therefore migration usually has a performance impact.
 
-QUIC probing packets, which can be sent on multiple paths at once, are used
-to perform address validation as well as measure path characteristics as input
-for the switching decision. Probing packets cannot carry application data but
-may contain padding frames. Endpoints can use information about their receipt
-as input to congestion control for that path. Applications could use
-information learned from probing to inform a decisions to switch paths.
+QUIC probing packets, which can be sent on multiple paths at once, are used to
+perform address validation as well as measure path characteristics.  Probing
+packets cannot carry application data but likely contain padding frames.
+Endpoints can use information about their receipt as input to congestion control
+for that path. Applications could use information learned from probing to inform
+a decisions to switch paths.
 
 Only the client can actively migrate in version 1 of QUIC. However, servers can
 indicate during the handshake that they prefer to transfer the connection to a


### PR DESCRIPTION
The text here mentioned the decision to use a new path twice.  Also,
probing packets almost always include padding frames now: we require
that the datagram is full-sized when probing so that we can probe for
MTU, and probing is almost certainly done with short header packets,
where padding has to be inside the packet.