### PR TITLE
Handshake packets that are sent before cryptographic context is estab…

### DIFF
--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -476,11 +476,11 @@ unlikely to be useful.
 
 The packet number field is always present in the QUIC packet header in version
 1; however, it is always encrypted. The encryption key for packet number
-protection on handshake packets sent before cryptographic context establishment
-is specific to the QUIC version, while packet number protection on subsequent
-packets uses secrets derived from the end-to-end cryptographic context. Packet
-numbers are therefore not part of the wire image that is visible to on-path
-observers.
+protection on Initial packets -- which are sent before cryptographic context
+establishment -- is specific to the QUIC version, while packet number protection
+on subsequent packets uses secrets derived from the end-to-end cryptographic
+context. Packet numbers are therefore not part of the wire image that is visible
+to on-path observers.
 
 
 ## Version Negotiation and Greasing {#version}


### PR DESCRIPTION
…lished

Are called Initial packets.