### PR TITLE
PR to refer to network-layer management/analysis

### DIFF
--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -833,7 +833,9 @@ packet header (Section 6 of
 {{?I-D.ietf-tsvwg-transport-encrypt}} describes use of operations,
 administration and management (OAM) information).
 Using network-layer approaches also has the advantage that common observation
-and analysis tools can be consistently used by multiple transport protocols.
+and analysis tools can be consistently used by multiple transport protocols,
+however, these techniques are often limited to measurements within one or
+multiple cooperating domains.
 
 ## Stateful Treatment of QUIC Traffic {#sec-stateful}
 

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -721,7 +721,7 @@ traffic is protected and ACKs may be padded, padding is not required.
 
 ## Round-Trip Time (RTT) Measurement {#sec-rtt}
 
-The round-trip time of QUIC flows can be inferred by observation once per flow,
+The round-trip time (RTT) of QUIC flows can be inferred by observation once per flow,
 during the handshake, as in passive TCP measurement; this requires parsing of
 the QUIC packet header and recognition of the handshake, as illustrated in
 {{handshake}}. It can also be inferred during the flow's lifetime, if the
@@ -765,7 +765,7 @@ signaling for a given connection can use a fixed spin value for the duration of
 the connection, or can set the bit randomly on each packet sent.
 
 When in use, the latency spin bit in each direction changes value once per
-round-trip time (RTT) any time that both endpoints are sending packets
+RTT any time that both endpoints are sending packets
 continuously. An on-path observer can observe the time difference between edges
 (changes from 1 to 0 or 0 to 1) in the spin bit signal in a single direction to
 measure one sample of end-to-end RTT. This mechanism follows the principles of
@@ -823,8 +823,16 @@ techniques and how QUIC's design impacts them.
 
 Limited RTT measurement is possible by passive observation of QUIC traffic;
 see {{sec-rtt}}. No passive measurement of loss is possible with the present
-wire image. Extremely limited observation of upstream congestion may be
+wire image. Limited observation of upstream congestion may be
 possible via the observation of CE markings on ECN-enabled QUIC traffic.
+
+On-path devices can also make measurements of RTT, loss and other 
+performance metrics when information is carried in an additional network-layer 
+packet header (Section 6 of
+{{?I-D.ietf-tsvwg-transport-encrypt}} describes use of operations,
+administration and management (OAM) information).
+Using network-layer approaches also has the potential that common observation
+and analysis tools can be consistently used by multiple transport protocols.
 
 ## Stateful Treatment of QUIC Traffic {#sec-stateful}
 

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -832,7 +832,7 @@ performance metrics when information is carried in an additional network-layer
 packet header (Section 6 of
 {{?I-D.ietf-tsvwg-transport-encrypt}} describes use of operations,
 administration and management (OAM) information).
-Using network-layer approaches also has the potential that common observation
+Using network-layer approaches also has the advantage that common observation
 and analysis tools can be consistently used by multiple transport protocols.
 
 ## Stateful Treatment of QUIC Traffic {#sec-stateful}

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -721,7 +721,8 @@ traffic is protected and ACKs may be padded, padding is not required.
 
 ## Round-Trip Time (RTT) Measurement {#sec-rtt}
 
-The round-trip time (RTT) of QUIC flows can be inferred by observation once per flow,
+The round-trip time (RTT) of QUIC flows can be inferred 
+by observation once per flow,
 during the handshake, as in passive TCP measurement; this requires parsing of
 the QUIC packet header and recognition of the handshake, as illustrated in
 {{handshake}}. It can also be inferred during the flow's lifetime, if the

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -721,7 +721,7 @@ traffic is protected and ACKs may be padded, padding is not required.
 
 ## Round-Trip Time (RTT) Measurement {#sec-rtt}
 
-The round-trip time (RTT) of QUIC flows can be inferred 
+The round-trip time (RTT) of QUIC flows can be inferred
 by observation once per flow,
 during the handshake, as in passive TCP measurement; this requires parsing of
 the QUIC packet header and recognition of the handshake, as illustrated in

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -828,7 +828,7 @@ wire image. Limited observation of upstream congestion may be
 possible via the observation of CE markings on ECN-enabled QUIC traffic.
 
 On-path devices can also make measurements of RTT, loss and other 
-performance metrics when information is carried in an additional network-layer 
+performance metrics when information is carried in an additional network-layer
 packet header (Section 6 of
 {{?I-D.ietf-tsvwg-transport-encrypt}} describes use of operations,
 administration and management (OAM) information).

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -827,7 +827,7 @@ see {{sec-rtt}}. No passive measurement of loss is possible with the present
 wire image. Limited observation of upstream congestion may be
 possible via the observation of CE markings on ECN-enabled QUIC traffic.
 
-On-path devices can also make measurements of RTT, loss and other 
+On-path devices can also make measurements of RTT, loss and other
 performance metrics when information is carried in an additional network-layer
 packet header (Section 6 of
 {{?I-D.ietf-tsvwg-transport-encrypt}} describes use of operations,


### PR DESCRIPTION
Refers to quicwg#362. 
This also addresses /extremely limited/ ECN visibility (limited for sure, but we don't need to say "extremely").
Fixed multiple definitions of RTT
Refered to metrics, etc for encrypted traffic wrt network-layer measurement via a REF.