### PR TITLE
migration and address linkability at the server

### DIFF
--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -634,10 +634,10 @@ handshake of the server for a preferred address to be used.
 Use of a non-zero-length connection ID for the server is strongly recommended if
 any clients are behind a NAT or could be. A non-zero-length connection ID is
 also strongly recommended when active migration is supported. If a connection
-is intentionally migrated to new path, an new connection ID is used to minimize
-linkability by network observers; of the other QUIC endpoint, however, is
-of course able to link different addresses to the same connection and entity
-if a non-zero-length connection ID is provided.
+is intentionally migrated to new path, a new connection ID is used to minimize
+linkability by network observers. The other QUIC endpoint uses the
+connection ID to link different addresses to the same connection
+and entity if a non-zero-length connection ID is provided.
 
 The base specification of QUIC version 1 only supports the use of a single
 network path at a time, which
@@ -747,8 +747,8 @@ using the connection ID.
 
 While sufficiently robust connection ID generation schemes will mitigate
 linkability for on-path observers, they do not provide full protection.
-Of course, the server uses the connection ID to associate packets to the same
-QUIC connection and as such can also link differeet IP addresses to the same
+The server uses the connection ID to associate packets to a QUIC
+connection and as such can also link different IP addresses to the same
 user. Further, analysis of
 the lifetimes of six-tuples (source and destination addresses as well as the
 migrated CID) may expose these links as well to on-path observers.

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -905,7 +905,9 @@ See the security considerations in {{QUIC}} and {{!QUIC-TLS}}; the security
 considerations for the underlying transport protocol are relevant for
 applications using QUIC, as well. Considerations on linkability, replay attacks,
 and randomness discussed in {{!QUIC-TLS}} should be taken into account when
-deploying and using QUIC. Further, migration to an new address exposes
+deploying and using QUIC.
+
+Further, migration to an new address exposes
 a linkage between client addresses to the server and may expose this linkage
 also to the path if the connection ID cannot be changed or flows can
 otherwise be correlated. When migration is supported, this needs to be

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -746,12 +746,9 @@ ensures that activity on different paths cannot be trivially correlated
 using the connection ID.
 
 While sufficiently robust connection ID generation schemes will mitigate
-linkability for on-path observers, they do not provide full protection.
-The server uses the connection ID to associate packets to a QUIC
-connection and as such can also link different IP addresses to the same
-user. Further, analysis of
+linkability issues, they do not provide full protection. Analysis of
 the lifetimes of six-tuples (source and destination addresses as well as the
-migrated CID) may expose these links as well to on-path observers.
+migrated CID) may expose these links anyway.
 
 In the limit where connection migration in a server pool is rare, it is trivial
 for an observer to associate two connection IDs. Conversely, in the opposite

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -906,7 +906,9 @@ considerations for the underlying transport protocol are relevant for
 applications using QUIC, as well. Considerations on linkability, replay attacks,
 and randomness discussed in {{!QUIC-TLS}} should be taken into account when
 deploying and using QUIC. Further, migration to an new address exposes
-a linkage between client addresses to the server which should also be
+a linkage between client addresses to the server and may expose this linkage
+also to the path if the connection ID cannot be changed or flows can
+otherwise be correlated. When migration is supported, this needs to be
 considered with respective to user privacy.
 
 Application developers should note that any fallback they use when QUIC cannot

--- a/draft-ietf-quic-applicability.md
+++ b/draft-ietf-quic-applicability.md
@@ -633,7 +633,11 @@ handshake of the server for a preferred address to be used.
 
 Use of a non-zero-length connection ID for the server is strongly recommended if
 any clients are behind a NAT or could be. A non-zero-length connection ID is
-also strongly recommended when migration is supported.
+also strongly recommended when active migration is supported. If a connection
+is intentionally migrated to new path, an new connection ID is used to minimize
+linkability by network observers; of the other QUIC endpoint, however, is
+of course able to link different addresses to the same connection and entity
+if a non-zero-length connection ID is provided.
 
 The base specification of QUIC version 1 only supports the use of a single
 network path at a time, which
@@ -742,9 +746,12 @@ ensures that activity on different paths cannot be trivially correlated
 using the connection ID.
 
 While sufficiently robust connection ID generation schemes will mitigate
-linkability issues, they do not provide full protection. Analysis of
+linkability for on-path observers, they do not provide full protection.
+Of course, the server uses the connection ID to associate packets to the same
+QUIC connection and as such can also link differeet IP addresses to the same
+user. Further, analysis of
 the lifetimes of six-tuples (source and destination addresses as well as the
-migrated CID) may expose these links anyway.
+migrated CID) may expose these links as well to on-path observers.
 
 In the limit where connection migration in a server pool is rare, it is trivial
 for an observer to associate two connection IDs. Conversely, in the opposite
@@ -898,7 +905,9 @@ See the security considerations in {{QUIC}} and {{!QUIC-TLS}}; the security
 considerations for the underlying transport protocol are relevant for
 applications using QUIC, as well. Considerations on linkability, replay attacks,
 and randomness discussed in {{!QUIC-TLS}} should be taken into account when
-deploying and using QUIC.
+deploying and using QUIC. Further, migration to an new address exposes
+a linkage between client addresses to the server which should also be
+considered with respective to user privacy.
 
 Application developers should note that any fallback they use when QUIC cannot
 be used due to network blocking of UDP should guarantee the same security


### PR DESCRIPTION
This would be my proposal of a few small additions based on the discussion on list and at the last meeting (IETF-112) about privacy implications after migration regarding exposure of linkable user IP addresses to the server. The text doesn't give any recommendations but at least mentions it in the relevant sections.