### PR TITLE
Use of encrypted message for Version negotiation

### DIFF
--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -493,7 +493,7 @@ to on-path observers.
 Version Negotiation packets are used by the server to indicate that a requested
 version from the client is not supported (see {{Section 6 of QUIC-TRANSPORT}}.
 Version Negotiation packets are not intrinsically protected, but future QUIC
-versions may use later encrypted messages to verify that they were authentic.
+versions could use later encrypted messages to verify that they were authentic.
 Therefore, any modification of this list will be detected and may cause the
 endpoints to terminate the connection attempt.
 

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -493,7 +493,7 @@ to on-path observers.
 Version Negotiation packets are used by the server to indicate that a requested
 version from the client is not supported (see {{Section 6 of QUIC-TRANSPORT}}.
 Version Negotiation packets are not intrinsically protected, but future QUIC
-versions will use later encrypted messages to verify that they were authentic.
+versions may use later encrypted messages to verify that they were authentic.
 Therefore, any modification of this list will be detected and may cause the
 endpoints to terminate the connection attempt.
 


### PR DESCRIPTION
Currently the document uses "will".  This might be a very valid assumption, but still it is an assumption hence I think it is better to use "May" instead of "Will".