### PR TITLE
Remove claim of header immutability from intro

### DIFF
--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -87,8 +87,7 @@ is exposed by QUIC to the network, requirements and assumptions of the QUIC
 design with respect to network treatment, and a description of how common
 network management practices will be impacted by QUIC.
 
-QUIC is an end-to-end transport protocol. No information in the protocol header,
-even that which can be inspected, is mutable by the network. This is
+QUIC is an end-to-end transport protocol. This property is
 enforced through integrity protection of the wire image {{?WIRE-IMAGE=RFC8546}}.
 Encryption of most transport-layer control signaling means that less information
 is visible to the network than is the case with TCP.

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -87,7 +87,9 @@ is exposed by QUIC to the network, requirements and assumptions of the QUIC
 design with respect to network treatment, and a description of how common
 network management practices will be impacted by QUIC.
 
-QUIC is an end-to-end transport protocol. This property is
+QUIC is an end-to-end transport protocol; therefore, no information in
+the protocol header is intended to be mutable by the network. This
+property is
 enforced through integrity protection of the wire image {{?WIRE-IMAGE=RFC8546}}.
 Encryption of most transport-layer control signaling means that less information
 is visible to the network than is the case with TCP.


### PR DESCRIPTION
fix #489. Wire image mutability is more subtle than "is completely immutable", and we get into the details later. New text is sufficient as contrast for TCP.