### PR TITLE
remove "traditional": we know what TCP is. :)

### DIFF
--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -1126,7 +1126,7 @@ connection could result in variations in order, delivery rate, and drop rate.
 As feedback about loss or delay of each packet is used as input to
 the congestion controller, these variations could adversely affect performance.
 Depending on the loss recovery mechanism implemented, QUIC may be
-more tolerant of packet re-ordering than traditional TCP traffic (see
+more tolerant of packet re-ordering than TCP traffic (see
 {{packetnumber}}). However, the recovery mechanism used by a flow cannot be
 known by the network and therefore reordering tolerance should be
 considered as unknown.

--- a/draft-ietf-quic-manageability.md
+++ b/draft-ietf-quic-manageability.md
@@ -1126,7 +1126,7 @@ connection could result in variations in order, delivery rate, and drop rate.
 As feedback about loss or delay of each packet is used as input to
 the congestion controller, these variations could adversely affect performance.
 Depending on the loss recovery mechanism implemented, QUIC may be
-more tolerant of packet re-ordering than TCP traffic (see
+more tolerant of packet re-ordering than typical TCP traffic (see
 {{packetnumber}}). However, the recovery mechanism used by a flow cannot be
 known by the network and therefore reordering tolerance should be
 considered as unknown.


### PR DESCRIPTION
fix #480 